### PR TITLE
Bump to 0.5.1, with dependencies and document updated.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           toolchain: stable
           command: generate-lockfile
 
-      - name: Setup cache
+      - name: Setup cargo cache
         uses: actions/cache@v3
         with:
           path: |
@@ -182,7 +182,7 @@ jobs:
           toolchain: stable
           command: generate-lockfile
 
-      - name: Setup cache
+      - name: Setup cargo cache
         uses: actions/cache@v3
         with:
           path: |
@@ -191,7 +191,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.os }}-ci-${{ matrix.php-version }}-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-check-${{ matrix.php-version }}-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cargo check phper-sys
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,23 @@ jobs:
           override: true
           components: clippy
 
+      - name: Cargo generate lockfile
+        uses: actions-rs/cargo@v1
+        with:
+          toolchain: stable
+          command: generate-lockfile
+
+      - name: Setup cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-ci-${{ matrix.php-version }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -158,6 +175,23 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - name: Cargo generate lockfile
+        uses: actions-rs/cargo@v1
+        with:
+          toolchain: stable
+          command: generate-lockfile
+
+      - name: Setup cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-ci-${{ matrix.php-version }}-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cargo check phper-sys
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ The framework that allows us to write PHP extensions using pure and safe Rust wh
    }
    ```
 
+1. Create the `build.rs` ( Adapting MacOS ).
+
+   ```rust,no_run
+   fn main() {
+      #[cfg(target_os = "macos")]
+      {
+         println!("cargo:rustc-link-arg=-undefined");
+         println!("cargo:rustc-link-arg=dynamic_lookup");
+      }
+   }
+   ```
+
 1. Write you owned extension logic in `lib.rs`.
 
    ```rust
@@ -124,6 +136,10 @@ The framework that allows us to write PHP extensions using pure and safe Rust wh
 ## Examples
 
 See [examples](https://github.com/phper-framework/phper/tree/master/examples).
+
+## The projects using PHPER
+
+- [apache/skywalking-php](https://github.com/apache/skywalking-php) - The PHP Agent for Apache SkyWalking, which provides the native tracing abilities for PHP project.
 
 ## License
 

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -29,10 +29,10 @@ path = "src/_reexport.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-phper = { version = "0.5.0", path = "../../phper" }
+phper = { version = "0.5.1", path = "../../phper" }
 
 [dev-dependencies]
-phper-test = { version = "0.5.0", path = "../../phper-test" }
+phper-test = { version = "0.5.1", path = "../../phper-test" }
 
 [build-dependencies]
-phper-build = { version = "0.5.0", path = "../../phper-build" }
+phper-build = { version = "0.5.1", path = "../../phper-build" }

--- a/examples/http-client/Cargo.toml
+++ b/examples/http-client/Cargo.toml
@@ -32,9 +32,9 @@ crate-type = ["cdylib"]
 anyhow = "1.0.58"
 bytes = "1.1.0"
 indexmap = "1.9.1"
-phper = { version = "0.5.0", path = "../../phper" }
+phper = { version = "0.5.1", path = "../../phper" }
 reqwest = { version = "0.11.11", features = ["blocking", "cookies"] }
 thiserror = "1.0.31"
 
 [dev-dependencies]
-phper-test = { version = "0.5.0", path = "../../phper-test" }
+phper-test = { version = "0.5.1", path = "../../phper-test" }

--- a/examples/http-server/Cargo.toml
+++ b/examples/http-server/Cargo.toml
@@ -30,10 +30,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 hyper = { version = "0.14.20", features = ["http1", "runtime", "server"] }
-phper = { version = "0.5.0", path = "../../phper" }
+phper = { version = "0.5.1", path = "../../phper" }
 thiserror = "1.0.31"
 tokio = { version = "1.19.2", features = ["full"] }
 
 [dev-dependencies]
-phper-test = { version = "0.5.0", path = "../../phper-test" }
+phper-test = { version = "0.5.1", path = "../../phper-test" }
 reqwest = "0.11.11"

--- a/examples/logging/Cargo.toml
+++ b/examples/logging/Cargo.toml
@@ -30,10 +30,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.58"
-phper = { version = "0.5.0", path = "../../phper" }
+phper = { version = "0.5.1", path = "../../phper" }
 
 [dev-dependencies]
-phper-test = { version = "0.5.0", path = "../../phper-test" }
+phper-test = { version = "0.5.1", path = "../../phper-test" }
 
 [build-dependencies]
-phper-build = { version = "0.5.0", path = "../../phper-build" }
+phper-build = { version = "0.5.1", path = "../../phper-build" }

--- a/phper-alloc/Cargo.toml
+++ b/phper-alloc/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "phper-alloc"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["PHPER Framework Team", "jmjoy <jmjoy@apache.org>"]
 edition = "2021"
 rust-version = "1.56"
@@ -22,7 +22,7 @@ keywords = ["php", "alloc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-phper-sys = { version = "0.5.0", path = "../phper-sys" }
+phper-sys = { version = "0.5.1", path = "../phper-sys" }
 
 [build-dependencies]
-phper-build = { version = "0.5.0", path = "../phper-build" }
+phper-build = { version = "0.5.1", path = "../phper-build" }

--- a/phper-build/Cargo.toml
+++ b/phper-build/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "phper-build"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["PHPER Framework Team", "jmjoy <jmjoy@apache.org>"]
 edition = "2021"
 rust-version = "1.56"
@@ -22,4 +22,4 @@ keywords = ["php", "binding"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-phper-sys = { version = "0.5.0", path = "../phper-sys" }
+phper-sys = { version = "0.5.1", path = "../phper-sys" }

--- a/phper-macros/Cargo.toml
+++ b/phper-macros/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "phper-macros"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["PHPER Framework Team", "jmjoy <jmjoy@apache.org>"]
 edition = "2021"
 rust-version = "1.56"

--- a/phper-sys/Cargo.toml
+++ b/phper-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "phper-sys"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["PHPER Framework Team", "jmjoy <jmjoy@apache.org>"]
 edition = "2021"
 rust-version = "1.56"

--- a/phper-test/Cargo.toml
+++ b/phper-test/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "phper-test"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["PHPER Framework Team", "jmjoy <jmjoy@apache.org>"]
 edition = "2021"
 rust-version = "1.56"
@@ -25,10 +25,10 @@ keywords = ["php", "binding"]
 fpm = ["fastcgi-client", "tokio/full"]
 
 [dependencies]
-fastcgi-client = { version = "0.7.0", optional = true }
+fastcgi-client = { version = "0.8.0", optional = true }
 libc = "0.2.126"
 once_cell = "1.13.0"
-phper-macros = { version = "0.5.0", path = "../phper-macros" }
+phper-macros = { version = "0.5.1", path = "../phper-macros" }
 tempfile = "3.3.0"
 tokio = { version = "1.19.2", optional = true }
 

--- a/phper/Cargo.toml
+++ b/phper/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "phper"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["PHPER Framework Team", "jmjoy <jmjoy@apache.org>"]
 edition = "2021"
 rust-version = "1.56"
@@ -18,7 +18,7 @@ description = "The framework that allows us to write PHP extensions using pure a
 repository = "https://github.com/jmjoy/phper.git"
 documentation = "https://docs.rs/phper"
 license = "MulanPSL-2.0"
-readme = "../README.md"
+readme = "README.md"
 keywords = ["php", "binding", "extension", "module"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -30,11 +30,11 @@ dashmap = "5.3.4"
 derive_more = "0.99.17"
 indexmap = "1.9.1"
 once_cell = "1.13.0"
-phper-alloc = { version = "0.5.0", path = "../phper-alloc" }
-phper-macros = { version = "0.5.0", path = "../phper-macros" }
-phper-sys = { version = "0.5.0", path = "../phper-sys" }
+phper-alloc = { version = "0.5.1", path = "../phper-alloc" }
+phper-macros = { version = "0.5.1", path = "../phper-macros" }
+phper-sys = { version = "0.5.1", path = "../phper-sys" }
 thiserror = "1.0.31"
 
 [build-dependencies]
-phper-build = { version = "0.5.0", path = "../phper-build" }
-phper-sys = { version = "0.5.0", path = "../phper-sys" }
+phper-build = { version = "0.5.1", path = "../phper-build" }
+phper-sys = { version = "0.5.1", path = "../phper-sys" }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 indexmap = "1.9.1"
-phper = { version = "0.5.0", path = "../../phper" }
+phper = { version = "0.5.1", path = "../../phper" }
 
 [dev-dependencies]
-phper-test = { version = "0.5.0", path = "../../phper-test", features = ["fpm"] }
+phper-test = { version = "0.5.1", path = "../../phper-test", features = ["fpm"] }


### PR DESCRIPTION
1. Bump to 0.5.1.
2. Upgrade `fastcgi-client`.
3. Update documnet.
4. Update CI with cache.