### PR TITLE
Adapt to PHP 8.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The framework that allows us to write PHP extensions using pure and safe Rust wh
     - [x] 7.4
     - [x] 8.0
     - [x] 8.1
+    - [x] 8.2
   - **mode**
     - [x] nts
     - [ ] zts

--- a/phper-doc/doc/_05_internal_types/_02_z_arr/index.md
+++ b/phper-doc/doc/_05_internal_types/_02_z_arr/index.md
@@ -41,7 +41,7 @@ let _i = arr.get("10");
 arr.remove("foo");
 ```
 
-`ZArr` can be iterated by `iter()`.
+`ZArr` can be iterated by `for_each()`.
 
 ```rust,no_run
 use phper::arrays::ZArray;
@@ -49,9 +49,15 @@ use phper::values::ZVal;
 
 let arr = ZArray::new();
 
-for (_k, _v) in arr.iter() {
-}
+
+arr.for_each(|k, v| {
+    dbg!(k, v);
+});
 ```
+
+*I used to provide the `iter()` method for `ZArr`, and let `Iter` implement
+`Iterator`, but if using the PHP stable macro `ZEND_HASH_FOREACH_KEY_VAL`, it is a
+bit difficult to provide `iter`, so it is deleted.*;
 
 `ZArr` implements `ToOwned`, can upgrade to `ZArray` by value copy via
 `zend_array_dup`.

--- a/phper-sys/build.rs
+++ b/phper-sys/build.rs
@@ -42,6 +42,8 @@ fn main() {
     let mut builder = Builder::default()
         .header("php_wrapper.c")
         .allowlist_file("php_wrapper\\.c")
+        // Block the `zend_ini_parse_quantity` because it's document causes the doc test to fail.
+        .blocklist_function("zend_ini_parse_quantity")
         .clang_args(&includes)
         .derive_default(true);
 

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -365,6 +365,26 @@ uint32_t phper_zend_num_args(const zend_execute_data *execute_data) {
     return ZEND_NUM_ARGS();
 }
 
-zend_bool phper_instanceof_function(const zend_class_entry *instance_ce, const zend_class_entry *ce) {
-    return instanceof_function(instance_ce, ce);
+bool phper_instanceof_function(const zend_class_entry *instance_ce, const zend_class_entry *ce) {
+    return instanceof_function(instance_ce, ce) != 0;
+}
+
+bool phper_zend_get_parameters_array_ex(uint32_t param_count, zval *argument_array) {
+    return zend_get_parameters_array_ex(param_count, argument_array) != 0;
+}
+
+bool phper_zend_array_is_list(zend_array *array) {
+    return zend_array_is_list(array) != 0;
+}
+
+typedef void (*phper_foreach_func_arg_t)(zend_ulong idx, zend_string *key, zval *val, void *argument);
+
+void phper_zend_hash_foreach_key_val(zend_array *array, phper_foreach_func_arg_t f, void *argument) {
+    zend_ulong idx;
+    zend_string *key;
+    zval *val;
+
+    ZEND_HASH_FOREACH_KEY_VAL(array, idx, key, val) {
+        f(idx, key, val, argument);
+    } ZEND_HASH_FOREACH_END();
 }

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -373,10 +373,6 @@ bool phper_zend_get_parameters_array_ex(uint32_t param_count, zval *argument_arr
     return zend_get_parameters_array_ex(param_count, argument_array) != 0;
 }
 
-bool phper_zend_array_is_list(zend_array *array) {
-    return zend_array_is_list(array) != 0;
-}
-
 typedef void (*phper_foreach_func_arg_t)(zend_ulong idx, zend_string *key, zval *val, void *argument);
 
 void phper_zend_hash_foreach_key_val(zend_array *array, phper_foreach_func_arg_t f, void *argument) {

--- a/phper/src/arrays.rs
+++ b/phper/src/arrays.rs
@@ -17,7 +17,7 @@ use std::{
     convert::TryInto,
     marker::PhantomData,
     mem::{forget, ManuallyDrop},
-    ops::{Deref, DerefMut},
+    ops::{Deref, DerefMut}, ffi::c_void,
 };
 
 /// Key for [ZArr].
@@ -103,10 +103,17 @@ impl ZArr {
         self.len() == 0
     }
 
-    // Get items length.
+    /// Get items length.
     #[inline]
     pub fn len(&mut self) -> usize {
         unsafe { zend_array_count(self.as_mut_ptr()).try_into().unwrap() }
+    }
+
+    /// Detect wether the array is list (not map).
+    pub fn is_list(&self) -> bool {
+        unsafe {
+            phper_zend_array_is_list(self.as_ptr() as *mut _)
+        }
     }
 
     /// Add or update item by key.
@@ -243,10 +250,11 @@ impl ZArr {
         }
     }
 
-    pub fn iter(&self) -> Iter<'_> {
-        Iter {
-            index: 0,
-            array: self,
+    pub fn for_each<'a>(&self, f: impl FnMut(IterKey<'a> ,&ZVal)) {
+        let mut f: Box<dyn FnMut(IterKey<'a> ,&ZVal)> = Box::new(f);
+        let f = &mut f as *mut Box<_> as *mut c_void;
+        unsafe {
+            phper_zend_hash_foreach_key_val(self.as_ptr() as *mut _, Some(for_each_callback), f);
         }
     }
 
@@ -373,46 +381,14 @@ pub enum IterKey<'a> {
     ZStr(&'a ZStr),
 }
 
-/// Iter created by [ZArr::iter].
-pub struct Iter<'a> {
-    index: isize,
-    array: &'a ZArr,
-}
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = (IterKey<'a>, &'a ZVal);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if self.index >= self.array.inner.nNumUsed as isize {
-                break None;
-            }
-
-            unsafe {
-                let bucket = self.array.inner.arData.offset(self.index);
-
-                let key = if (*bucket).key.is_null() {
-                    IterKey::Index((*bucket).h)
-                } else {
-                    let s = ZStr::from_ptr((*bucket).key);
-                    IterKey::ZStr(s)
-                };
-
-                let val = &mut (*bucket).val;
-                let mut val = ZVal::from_mut_ptr(val);
-                if val.get_type_info().is_indirect() {
-                    val = ZVal::from_mut_ptr((*val.as_mut_ptr()).value.zv);
-                }
-
-                self.index += 1;
-
-                if val.get_type_info().is_undef() {
-                    continue;
-                }
-                break Some((key, val));
-            }
-        }
-    }
+unsafe extern "C" fn for_each_callback(idx: zend_ulong, key: *mut zend_string, val: *mut zval, argument: *mut c_void) {
+    let f = (argument as *mut Box<dyn FnMut(IterKey<'_> ,&ZVal)>).as_mut().unwrap();
+    let iter_key = if key.is_null() {
+        IterKey::Index(idx as u64)
+    } else {
+        IterKey::ZStr(ZStr::from_ptr(key))
+    };
+    f(iter_key, ZVal::from_ptr(val));
 }
 
 pub enum Entry<'a> {

--- a/phper/src/arrays.rs
+++ b/phper/src/arrays.rs
@@ -368,7 +368,7 @@ impl Drop for ZArray {
     }
 }
 
-/// Iterator key for [Iter].
+/// Iterator key for [`ZArr::for_each`].
 #[derive(Debug, Clone, PartialEq, From)]
 pub enum IterKey<'a> {
     Index(u64),

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -10,6 +10,8 @@
 
 //! Apis relate to [crate::sys::zval].
 
+use std::fmt;
+use std::fmt::{Debug};
 use crate::{
     alloc::EBox,
     arrays::{ZArr, ZArray},
@@ -132,7 +134,7 @@ impl ExecuteData {
         let num_args = self.num_args();
         let mut arguments = vec![zeroed::<zval>(); num_args as usize];
         if num_args > 0 {
-            _zend_get_parameters_array_ex(num_args.try_into().unwrap(), arguments.as_mut_ptr());
+            phper_zend_get_parameters_array_ex(num_args.try_into().unwrap(), arguments.as_mut_ptr());
         }
         transmute(arguments)
     }
@@ -375,6 +377,12 @@ impl ZVal {
     /// Return Err when self is not callable.
     pub fn call(&mut self, arguments: impl AsMut<[ZVal]>) -> crate::Result<ZVal> {
         call_internal(self, None, arguments)
+    }
+}
+
+impl Debug for ZVal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ZVal").field("type", &self.get_type_info()).finish()
     }
 }
 

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -10,8 +10,6 @@
 
 //! Apis relate to [crate::sys::zval].
 
-use std::fmt;
-use std::fmt::{Debug};
 use crate::{
     alloc::EBox,
     arrays::{ZArr, ZArray},
@@ -27,6 +25,8 @@ use phper_alloc::RefClone;
 use std::{
     convert::TryInto,
     ffi::CStr,
+    fmt,
+    fmt::Debug,
     marker::PhantomData,
     mem::{transmute, zeroed, ManuallyDrop, MaybeUninit},
     str,
@@ -134,7 +134,10 @@ impl ExecuteData {
         let num_args = self.num_args();
         let mut arguments = vec![zeroed::<zval>(); num_args as usize];
         if num_args > 0 {
-            phper_zend_get_parameters_array_ex(num_args.try_into().unwrap(), arguments.as_mut_ptr());
+            phper_zend_get_parameters_array_ex(
+                num_args.try_into().unwrap(),
+                arguments.as_mut_ptr(),
+            );
         }
         transmute(arguments)
     }
@@ -382,7 +385,9 @@ impl ZVal {
 
 impl Debug for ZVal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ZVal").field("type", &self.get_type_info()).finish()
+        f.debug_struct("ZVal")
+            .field("type", &self.get_type_info())
+            .finish()
     }
 }
 

--- a/tests/integration/src/arrays.rs
+++ b/tests/integration/src/arrays.rs
@@ -187,7 +187,7 @@ pub fn integrate(module: &mut Module) {
     );
 
     module.add_function(
-        "integrate_arrays_iter",
+        "integrate_arrays_for_each",
         |_: &mut [ZVal]| -> phper::Result<()> {
             let mut a = ZArray::new();
 
@@ -195,7 +195,9 @@ pub fn integrate(module: &mut Module) {
             a.insert((), ZVal::from(1));
             a.insert("foo", ZVal::from("bar"));
 
-            for (i, (k, v)) in a.iter().enumerate() {
+            let mut i = 0;
+
+            a.for_each(|k, v| {
                 match i {
                     0 => {
                         assert_eq!(k, 0.into());
@@ -211,7 +213,27 @@ pub fn integrate(module: &mut Module) {
                     }
                     _ => unreachable!(),
                 }
-            }
+
+                i += 1;
+            });
+
+            assert_eq!(i, 3);
+
+            Ok(())
+        },
+    );
+
+    module.add_function(
+        "integrate_arrays_is_list",
+        |_: &mut [ZVal]| -> phper::Result<()> {
+            let mut a = ZArray::new();
+            a.insert(InsertKey::NextIndex, ZVal::default());
+            a.insert(InsertKey::NextIndex, ZVal::default());
+            a.insert(InsertKey::NextIndex, ZVal::default());
+            assert!(a.is_list());
+
+            a.insert("foo", ZVal::default());
+            assert!(!a.is_list());
 
             Ok(())
         },

--- a/tests/integration/src/arrays.rs
+++ b/tests/integration/src/arrays.rs
@@ -222,20 +222,4 @@ pub fn integrate(module: &mut Module) {
             Ok(())
         },
     );
-
-    module.add_function(
-        "integrate_arrays_is_list",
-        |_: &mut [ZVal]| -> phper::Result<()> {
-            let mut a = ZArray::new();
-            a.insert(InsertKey::NextIndex, ZVal::default());
-            a.insert(InsertKey::NextIndex, ZVal::default());
-            a.insert(InsertKey::NextIndex, ZVal::default());
-            assert!(a.is_list());
-
-            a.insert("foo", ZVal::default());
-            assert!(!a.is_list());
-
-            Ok(())
-        },
-    );
 }

--- a/tests/integration/tests/php/arrays.php
+++ b/tests/integration/tests/php/arrays.php
@@ -17,4 +17,5 @@ assert_eq(integrate_arrays_new_drop(), "FOO BAR");
 integrate_arrays_types();
 integrate_arrays_insert();
 integrate_arrays_exists();
-integrate_arrays_iter();
+integrate_arrays_for_each();
+integrate_arrays_is_list();

--- a/tests/integration/tests/php/arrays.php
+++ b/tests/integration/tests/php/arrays.php
@@ -18,4 +18,3 @@ integrate_arrays_types();
 integrate_arrays_insert();
 integrate_arrays_exists();
 integrate_arrays_for_each();
-integrate_arrays_is_list();


### PR DESCRIPTION
1. Block function `zend_ini_parse_quantity`.
2. Replace `ZArr::iter` with `ZVal::for_each` because the struct field of `zend_array` has changed.
3. Add PHP 8.2 CI test.