### PR TITLE
Add references support, and rename ZendFunction.

### DIFF
--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -415,3 +415,21 @@ void phper_zend_hash_foreach_key_val(zend_array *array,
     }
     ZEND_HASH_FOREACH_END();
 }
+
+zend_internal_arg_info
+phper_zend_begin_arg_info_ex(bool return_reference,
+                             uintptr_t required_num_args) {
+#define static
+#define const
+    ZEND_BEGIN_ARG_INFO_EX(info, 0, return_reference, required_num_args)
+    ZEND_END_ARG_INFO()
+    return info[0];
+#undef static
+#undef const
+}
+
+zend_internal_arg_info phper_zend_arg_info(bool pass_by_ref, const char *name) {
+    zend_internal_arg_info info[] = {ZEND_ARG_INFO(pass_by_ref, )};
+    info[0].name = name;
+    return info[0];
+}

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -308,12 +308,12 @@ zend_array *phper_z_arr_p(const zval *zv) {
     return Z_ARR_P(zv);
 }
 
-zend_long phper_z_lval_p(const zval *zv) {
-    return Z_LVAL_P(zv);
+zend_long *phper_z_lval_p(zval *zv) {
+    return &(Z_LVAL_P(zv));
 }
 
-double phper_z_dval_p(const zval *zv) {
-    return Z_DVAL_P(zv);
+double *phper_z_dval_p(zval *zv) {
+    return &(Z_DVAL_P(zv));
 }
 
 zend_string *phper_z_str_p(const zval *zv) {
@@ -322,6 +322,10 @@ zend_string *phper_z_str_p(const zval *zv) {
 
 zend_resource *phper_z_res_p(const zval *zv) {
     return Z_RES_P(zv);
+}
+
+zend_reference *phper_z_ref_p(const zval *zv) {
+    return Z_REF_P(zv);
 }
 
 zend_string *phper_zend_string_copy(zend_string *s) {

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -28,7 +28,6 @@ use std::{
     ffi::{CStr, CString},
     marker::PhantomData,
     mem::{size_of, transmute, zeroed},
-    os::raw::c_char,
     ptr::null_mut,
     rc::Rc,
 };
@@ -137,15 +136,12 @@ impl FunctionEntry {
         let mut infos = Vec::new();
 
         let require_arg_count = arguments.iter().filter(|arg| arg.required).count();
-        infos.push(create_zend_arg_info(
-            require_arg_count as *const c_char,
-            false,
-        ));
+        infos.push(phper_zend_begin_arg_info_ex(false, require_arg_count));
 
         for arg in arguments {
-            infos.push(create_zend_arg_info(
-                arg.name.as_ptr().cast(),
+            infos.push(phper_zend_arg_info(
                 arg.pass_by_ref,
+                arg.name.as_ptr().cast(),
             ));
         }
 
@@ -444,55 +440,6 @@ unsafe extern "C" fn invoke(execute_data: *mut zend_execute_data, return_value: 
 
     // TODO catch_unwind for call, translate some panic to throwing Error.
     handler.call(execute_data, transmute(arguments), return_value);
-}
-
-pub(crate) const fn create_zend_arg_info(
-    name: *const c_char, _pass_by_ref: bool,
-) -> zend_internal_arg_info {
-    #[cfg(phper_major_version = "8")]
-    {
-        zend_internal_arg_info {
-            name,
-            type_: zend_type {
-                ptr: null_mut(),
-                type_mask: 0,
-            },
-            default_value: null_mut(),
-        }
-    }
-
-    #[cfg(all(
-        phper_major_version = "7",
-        any(
-            phper_minor_version = "4",
-            phper_minor_version = "3",
-            phper_minor_version = "2",
-        )
-    ))]
-    {
-        #[allow(clippy::unnecessary_cast)]
-        zend_internal_arg_info {
-            name,
-            type_: 0 as crate::sys::zend_type,
-            pass_by_reference: _pass_by_ref as zend_uchar,
-            is_variadic: 0,
-        }
-    }
-
-    #[cfg(all(
-        phper_major_version = "7",
-        any(phper_minor_version = "1", phper_minor_version = "0")
-    ))]
-    {
-        zend_internal_arg_info {
-            name,
-            class_name: std::ptr::null(),
-            type_hint: 0,
-            allow_null: 0,
-            pass_by_reference: _pass_by_ref as zend_uchar,
-            is_variadic: 0,
-        }
-    }
 }
 
 /// Call user function by name.

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -287,12 +287,12 @@ impl Argument {
 }
 
 #[repr(transparent)]
-pub struct ZendFunction {
+pub struct ZendFunc {
     inner: zend_function,
 }
 
-impl ZendFunction {
-    pub(crate) unsafe fn from_mut_ptr<'a>(ptr: *mut zend_function) -> &'a mut ZendFunction {
+impl ZendFunc {
+    pub(crate) unsafe fn from_mut_ptr<'a>(ptr: *mut zend_function) -> &'a mut ZendFunc {
         let ptr = ptr as *mut Self;
         ptr.as_mut().expect("ptr shouldn't be null")
     }

--- a/phper/src/objects.rs
+++ b/phper/src/objects.rs
@@ -13,7 +13,7 @@
 use crate::{
     alloc::EBox,
     classes::ClassEntry,
-    functions::{call_internal, ZendFunction},
+    functions::{call_internal, ZendFunc},
     sys::*,
     values::ZVal,
 };
@@ -231,7 +231,7 @@ impl ZObj {
                     if f.is_null() {
                         Ok(false)
                     } else {
-                        let zend_fn = ZendFunction::from_mut_ptr(f);
+                        let zend_fn = ZendFunc::from_mut_ptr(f);
                         zend_fn.call(Some(self), arguments)?;
                         Ok(true)
                     }

--- a/phper/src/references.rs
+++ b/phper/src/references.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 PHPER Framework Team
+// PHPER is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan
+// PSL v2. You may obtain a copy of Mulan PSL v2 at:
+//          http://license.coscl.org.cn/MulanPSL2
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
+//! Apis relate to [crate::sys::zend_resource].
+
+use crate::{sys::*, values::ZVal};
+
+/// Wrapper of [crate::sys::zend_resource].
+#[repr(transparent)]
+pub struct ZRef {
+    inner: zend_reference,
+}
+
+impl ZRef {
+    /// # Safety
+    ///
+    /// Create from raw pointer.
+    pub unsafe fn from_ptr<'a>(ptr: *const zend_reference) -> &'a Self {
+        (ptr as *const Self)
+            .as_ref()
+            .expect("ptr should not be null")
+    }
+
+    /// # Safety
+    ///
+    /// Create from raw pointer.
+    pub unsafe fn try_from_ptr<'a>(ptr: *const zend_reference) -> Option<&'a Self> {
+        (ptr as *const Self).as_ref()
+    }
+
+    /// # Safety
+    ///
+    /// Create from raw pointer.
+    pub unsafe fn from_mut_ptr<'a>(ptr: *mut zend_reference) -> &'a mut Self {
+        (ptr as *mut Self).as_mut().expect("ptr should not be null")
+    }
+
+    /// # Safety
+    ///
+    /// Create from raw pointer.
+    pub unsafe fn try_from_mut_ptr<'a>(ptr: *mut zend_reference) -> Option<&'a mut Self> {
+        (ptr as *mut Self).as_mut()
+    }
+
+    pub const fn as_ptr(&self) -> *const zend_reference {
+        &self.inner
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut zend_reference {
+        &mut self.inner
+    }
+
+    pub fn val(&self) -> &ZVal {
+        unsafe { ZVal::from_ptr(&self.inner.val) }
+    }
+
+    pub fn val_mut(&mut self) -> &mut ZVal {
+        unsafe { ZVal::from_mut_ptr(&mut self.inner.val) }
+    }
+}

--- a/phper/src/types.rs
+++ b/phper/src/types.rs
@@ -10,7 +10,7 @@
 
 //! Apis relate to PHP types.
 
-use crate::sys::*;
+use crate::{c_str, sys::*};
 use derive_more::From;
 use std::{ffi::CStr, fmt::Display, os::raw::c_int};
 
@@ -27,6 +27,7 @@ impl TypeInfo {
     pub const LONG: TypeInfo = TypeInfo::from_raw(IS_LONG);
     pub const NULL: TypeInfo = TypeInfo::from_raw(IS_NULL);
     pub const OBJECT: TypeInfo = TypeInfo::from_raw(IS_OBJECT);
+    pub const REFERENCE: TypeInfo = TypeInfo::from_raw(IS_REFERENCE);
     pub const RESOURCE: TypeInfo = TypeInfo::from_raw(IS_RESOURCE);
     pub const STRING: TypeInfo = TypeInfo::from_raw(IS_STRING);
     pub const UNDEF: TypeInfo = TypeInfo::from_raw(IS_UNDEF);
@@ -39,46 +40,6 @@ impl TypeInfo {
 
     pub const fn into_raw(self) -> u32 {
         self.t
-    }
-
-    pub const fn undef() -> TypeInfo {
-        Self::from_raw(IS_UNDEF)
-    }
-
-    pub const fn null() -> TypeInfo {
-        Self::from_raw(IS_NULL)
-    }
-
-    pub const fn bool(b: bool) -> TypeInfo {
-        Self::from_raw(if b { IS_TRUE } else { IS_FALSE })
-    }
-
-    pub const fn long() -> TypeInfo {
-        Self::from_raw(IS_LONG)
-    }
-
-    pub const fn double() -> TypeInfo {
-        Self::from_raw(IS_DOUBLE)
-    }
-
-    pub const fn string() -> TypeInfo {
-        Self::from_raw(IS_STRING)
-    }
-
-    pub const fn array() -> TypeInfo {
-        Self::from_raw(IS_ARRAY)
-    }
-
-    pub const fn array_ex() -> TypeInfo {
-        Self::from_raw(IS_ARRAY_EX)
-    }
-
-    pub const fn object() -> TypeInfo {
-        Self::from_raw(IS_OBJECT)
-    }
-
-    pub const fn object_ex() -> TypeInfo {
-        Self::from_raw(IS_OBJECT_EX)
     }
 
     pub const fn is_undef(self) -> bool {
@@ -125,16 +86,42 @@ impl TypeInfo {
         get_base_type_by_raw(self.t) == IS_RESOURCE
     }
 
-    pub const fn is_indirect(self) -> bool {
-        self.t == IS_INDIRECT
+    pub const fn is_reference(self) -> bool {
+        get_base_type_by_raw(self.t) == IS_REFERENCE
     }
 
     pub const fn get_base_type(self) -> TypeInfo {
         Self::from_raw(get_base_type_by_raw(self.t))
     }
 
-    pub fn get_base_type_name(self) -> crate::Result<String> {
-        get_type_by_const(self.t)
+    /// Can be sure, `zend_get_type_by_const` returns the const string, So this
+    /// method returns `&'static CStr`.
+    #[inline]
+    pub fn get_base_type_name(self) -> &'static CStr {
+        unsafe {
+            let t = get_base_type_by_raw(self.t);
+
+            if t == IS_UNDEF {
+                return c_str!("undef");
+            }
+            if t == IS_REFERENCE {
+                return c_str!("reference");
+            }
+
+            let s = zend_get_type_by_const(t as c_int);
+            let s = CStr::from_ptr(s);
+
+            // Compact with PHP7.
+            let bs = s.to_bytes();
+            if bs == b"boolean" {
+                return c_str!("bool");
+            }
+            if bs == b"integer" {
+                return c_str!("int");
+            }
+
+            s
+        }
     }
 }
 
@@ -146,43 +133,8 @@ impl From<u32> for TypeInfo {
 
 impl Display for TypeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let t = if self.is_null() {
-            "null"
-        } else if self.is_bool() {
-            "bool"
-        } else if self.is_long() {
-            "int"
-        } else if self.is_double() {
-            "float"
-        } else if self.is_string() {
-            "string"
-        } else if self.is_array() {
-            "array"
-        } else if self.is_object() {
-            "object"
-        } else if self.is_resource() {
-            "resource"
-        } else {
-            "unknown"
-        };
+        let t = self.get_base_type_name().to_str().unwrap_or("unknown");
         Display::fmt(t, f)
-    }
-}
-
-fn get_type_by_const(mut t: u32) -> crate::Result<String> {
-    unsafe {
-        t = get_base_type_by_raw(t);
-        let s = zend_get_type_by_const(t as c_int);
-        let mut s = CStr::from_ptr(s).to_str()?.to_string();
-
-        // Compact with PHP7.
-        if s == "boolean" {
-            s = "bool".to_string();
-        } else if s == "integer" {
-            s = "int".to_string();
-        }
-
-        Ok(s)
     }
 }
 

--- a/tests/integration/src/errors.rs
+++ b/tests/integration/src/errors.rs
@@ -8,10 +8,13 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-use phper::modules::Module;
+use phper::{
+    errors::{exception_class, ThrowObject},
+    modules::Module,
+};
 use std::io;
 
-pub fn integrate(_module: &mut Module) {
+pub fn integrate(module: &mut Module) {
     {
         let e = phper::Error::boxed("something wrong");
         assert!(matches!(e, phper::Error::Boxed(..)));
@@ -23,4 +26,14 @@ pub fn integrate(_module: &mut Module) {
         assert!(matches!(e, phper::Error::Boxed(..)));
         assert_eq!(e.to_string(), "oh no!");
     }
+
+    module.add_function("integrate_throw_boxed", |_arguments| {
+        Err::<(), _>(phper::Error::boxed("What's wrong with you?"))
+    });
+
+    module.add_function("integrate_throw_object", |_arguments| {
+        let obj = exception_class().new_object(["Forbidden".into(), 403.into()])?;
+        let obj = ThrowObject::new(obj)?;
+        Err::<(), _>(phper::Error::Throw(obj))
+    });
 }

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -18,6 +18,7 @@ mod errors;
 mod functions;
 mod ini;
 mod objects;
+mod references;
 mod strings;
 mod values;
 
@@ -41,6 +42,7 @@ pub fn get_module() -> Module {
     constants::integrate(&mut module);
     ini::integrate(&mut module);
     errors::integrate(&mut module);
+    references::integrate(&mut module);
 
     module
 }

--- a/tests/integration/src/references.rs
+++ b/tests/integration/src/references.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 PHPER Framework Team
+// PHPER is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan
+// PSL v2. You may obtain a copy of Mulan PSL v2 at:
+//          http://license.coscl.org.cn/MulanPSL2
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
+use phper::{functions::Argument, modules::Module};
+
+#[allow(clippy::disallowed_names)]
+pub fn integrate(module: &mut Module) {
+    module
+        .add_function("integrate_test_reference", |arguments| {
+            let foo = arguments[0].expect_mut_z_ref()?;
+            *foo.val().expect_mut_long()? += 100;
+
+            let bar = arguments[1].expect_z_ref()?;
+            bar.val().expect_null()?;
+
+            *arguments[1].as_mut_z_ref().unwrap().val_mut() = "hello".into();
+
+            Ok::<_, phper::Error>(())
+        })
+        .arguments([Argument::by_ref("foo"), Argument::by_ref("bar")]);
+}

--- a/tests/integration/src/values.rs
+++ b/tests/integration/src/values.rs
@@ -18,6 +18,7 @@ use phper::{
 
 pub fn integrate(module: &mut Module) {
     integrate_returns(module);
+    integrate_as(module);
 }
 
 fn integrate_returns(module: &mut Module) {
@@ -156,4 +157,38 @@ fn integration_values_return_result_string_err(_: &mut [ZVal]) -> phper::Result<
 
 fn integration_values_return_val(_: &mut [ZVal]) -> ZVal {
     ZVal::from("foo")
+}
+
+fn integrate_as(_module: &mut Module) {
+    {
+        let val = ZVal::default();
+        assert_eq!(val.as_null(), Some(()));
+        assert_eq!(val.as_long(), None);
+    }
+
+    {
+        let val = ZVal::from(true);
+        assert_eq!(val.as_bool(), Some(true));
+        assert_eq!(val.as_long(), None);
+    }
+
+    {
+        let mut val = ZVal::from(100i64);
+        assert_eq!(val.as_long(), Some(100));
+        assert_eq!(val.as_double(), None);
+        if let Some(l) = val.as_mut_long() {
+            *l += 100;
+        }
+        assert_eq!(val.as_long(), Some(200));
+    }
+
+    {
+        let mut val = ZVal::from(100f64);
+        assert_eq!(val.as_double(), Some(100.));
+        assert_eq!(val.as_long(), None);
+        if let Some(d) = val.as_mut_double() {
+            *d += 100.;
+        }
+        assert_eq!(val.as_double(), Some(200.));
+    }
 }

--- a/tests/integration/tests/integration.rs
+++ b/tests/integration/tests/integration.rs
@@ -38,6 +38,8 @@ fn test_cli() {
             &tests_php_dir.join("values.php"),
             &tests_php_dir.join("constants.php"),
             &tests_php_dir.join("ini.php"),
+            &tests_php_dir.join("references.php"),
+            &tests_php_dir.join("errors.php"),
         ],
     );
 }

--- a/tests/integration/tests/php/errors.php
+++ b/tests/integration/tests/php/errors.php
@@ -1,3 +1,5 @@
+<?php
+
 // Copyright (c) 2022 PHPER Framework Team
 // PHPER is licensed under Mulan PSL v2.
 // You can use this software according to the terms and conditions of the Mulan
@@ -8,29 +10,8 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-#![warn(rust_2018_idioms, clippy::dbg_macro, clippy::print_stdout)]
-#![doc = include_str!("../README.md")]
 
-#[macro_use]
-mod macros;
+require_once __DIR__ . '/_common.php';
 
-pub mod arrays;
-pub mod classes;
-pub(crate) mod constants;
-pub mod errors;
-pub mod functions;
-pub mod ini;
-pub mod modules;
-pub mod objects;
-pub mod output;
-pub mod references;
-pub mod resources;
-pub mod strings;
-pub mod types;
-mod utils;
-pub mod values;
-
-pub use crate::errors::{Error, Result};
-pub use phper_alloc as alloc;
-pub use phper_macros::*;
-pub use phper_sys as sys;
+assert_throw("integrate_throw_boxed", "ErrorException", 0, "What's wrong with you?");
+assert_throw("integrate_throw_object", "Exception", 403, "Forbidden");

--- a/tests/integration/tests/php/references.php
+++ b/tests/integration/tests/php/references.php
@@ -1,3 +1,5 @@
+<?php
+
 // Copyright (c) 2022 PHPER Framework Team
 // PHPER is licensed under Mulan PSL v2.
 // You can use this software according to the terms and conditions of the Mulan
@@ -8,29 +10,11 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-#![warn(rust_2018_idioms, clippy::dbg_macro, clippy::print_stdout)]
-#![doc = include_str!("../README.md")]
 
-#[macro_use]
-mod macros;
+require_once __DIR__ . '/_common.php';
 
-pub mod arrays;
-pub mod classes;
-pub(crate) mod constants;
-pub mod errors;
-pub mod functions;
-pub mod ini;
-pub mod modules;
-pub mod objects;
-pub mod output;
-pub mod references;
-pub mod resources;
-pub mod strings;
-pub mod types;
-mod utils;
-pub mod values;
+$foo = 100;
+integrate_test_reference($foo, $bar);
 
-pub use crate::errors::{Error, Result};
-pub use phper_alloc as alloc;
-pub use phper_macros::*;
-pub use phper_sys as sys;
+assert_eq($foo, 200);
+assert_eq($bar, "hello");


### PR DESCRIPTION
1. Add references support.
2. Rename ZendFunction To ZendFunc.
3. Add tests and references mod integration tests.