### PR TITLE
Re implement ExceptionGuard by myself.

### DIFF
--- a/phper/src/errors.rs
+++ b/phper/src/errors.rs
@@ -21,7 +21,7 @@ use std::{
     fmt::{self, Debug, Display},
     io,
     marker::PhantomData,
-    mem::replace,
+    mem::{replace, ManuallyDrop},
     ops::{Deref, DerefMut},
     ptr::null_mut,
     result,
@@ -504,6 +504,6 @@ impl Drop for ExceptionGuard {
 /// rather than use this function.
 pub unsafe fn throw(e: impl Throwable) {
     let obj = ThrowObject::from_throwable(e).into_inner();
-    let mut val = ZVal::from(obj);
+    let mut val = ManuallyDrop::new(ZVal::from(obj));
     zend_throw_exception_object(val.as_mut_ptr());
 }


### PR DESCRIPTION
I reorganized the `zend_exception_save` and `zend_exception_restore`, I think there may be issues with their nested usage, so I re implemented `ExceptionGuard`, the current logic is clear and easy to understand.