### PR TITLE
Update MSRV to 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@
 # See the Mulan PSL v2 for more details.
 
 [workspace]
+resolver = "2"
 members = [
     "phper",
     "phper-alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ authors = ["PHPER Framework Team", "jmjoy <jmjoy@apache.org>"]
 edition = "2021"
 license = "MulanPSL-2.0"
 repository = "https://github.com/phper-framework/phper"
-rust-version = "1.65"
+rust-version = "1.67"
 
 [workspace.dependencies]
 phper = { version = "0.12.0", path = "./phper" }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The framework that allows us to write PHP extensions using pure and safe Rust wh
 
 ### Necessary
 
-- **rust** 1.65 or later
+- **rust** 1.67 or later
 - **libclang** 9.0 or later
 - **php** 7.0 or later
 

--- a/phper/src/arrays.rs
+++ b/phper/src/arrays.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_array](crate::sys::zend_array).
+//! Apis relate to [zend_array].
 
 use crate::{alloc::ToRefOwned, strings::ZStr, sys::*, values::ZVal};
 use derive_more::From;
@@ -61,7 +61,7 @@ impl<'a> From<Key<'a>> for InsertKey<'a> {
     }
 }
 
-/// Wrapper of [zend_array](crate::sys::zend_array).
+/// Wrapper of [zend_array].
 #[repr(transparent)]
 pub struct ZArr {
     inner: zend_array,
@@ -359,7 +359,7 @@ impl ToRefOwned for ZArr {
     }
 }
 
-/// Wrapper of [zend_array](crate::sys::zend_array).
+/// Wrapper of [zend_array].
 #[repr(transparent)]
 pub struct ZArray {
     inner: *mut ZArr,

--- a/phper/src/classes.rs
+++ b/phper/src/classes.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_class_entry](crate::sys::zend_class_entry).
+//! Apis relate to [zend_class_entry].
 
 use crate::{
     arrays::ZArr,
@@ -48,7 +48,7 @@ pub fn array_access_class<'a>() -> &'a ClassEntry {
     unsafe { ClassEntry::from_ptr(zend_ce_arrayaccess) }
 }
 
-/// Wrapper of [zend_class_entry](crate::sys::zend_class_entry).
+/// Wrapper of [zend_class_entry].
 #[repr(transparent)]
 pub struct ClassEntry {
     inner: zend_class_entry,
@@ -206,7 +206,7 @@ fn find_global_class_entry_ptr(name: impl AsRef<str>) -> *mut zend_class_entry {
 }
 
 /// The [StaticStateClass] holds
-/// [zend_class_entry](crate::sys::zend_class_entry) and inner state, always as
+/// [zend_class_entry] and inner state, always as
 /// the static variable, and then be bind to [ClassEntity].
 ///
 /// When the class registered (module initialized), the [StaticStateClass] will
@@ -240,7 +240,7 @@ pub struct StaticStateClass<T> {
 
 impl<T> StaticStateClass<T> {
     /// Create empty [StaticStateClass], with null
-    /// [zend_class_entry](crate::sys::zend_class_entry).
+    /// [zend_class_entry].
     pub const fn null() -> Self {
         Self {
             inner: AtomicPtr::new(null_mut()),
@@ -284,7 +284,7 @@ impl<T> StaticStateClass<T> {
 unsafe impl<T> Sync for StaticStateClass<T> {}
 
 /// The [StaticInterface]  holds
-/// [zend_class_entry](crate::sys::zend_class_entry), always as the static
+/// [zend_class_entry], always as the static
 /// variable, and then be bind to [InterfaceEntity].
 ///
 /// When the interface registered (module initialized), the [StaticInterface]
@@ -313,7 +313,7 @@ pub struct StaticInterface {
 
 impl StaticInterface {
     /// Create empty [StaticInterface], with null
-    /// [zend_class_entry](crate::sys::zend_class_entry).
+    /// [zend_class_entry].
     pub const fn null() -> Self {
         Self {
             inner: AtomicPtr::new(null_mut()),

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_function_entry](crate::sys::zend_function_entry).
+//! Apis relate to [zend_function_entry].
 //!
 //! TODO Add lambda.
 

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -151,9 +151,7 @@ impl FunctionEntry {
             infos.push(last_arg_info);
         }
 
-        let flags = visibility
-            .map(|v| v as u32)
-            .unwrap_or(Visibility::default() as u32);
+        let flags = visibility.unwrap_or(Visibility::default() as u32);
 
         zend_function_entry {
             fname: name.as_ptr().cast(),

--- a/phper/src/ini.rs
+++ b/phper/src/ini.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_ini_entry_def](crate::sys::zend_ini_entry_def).
+//! Apis relate to [zend_ini_entry_def].
 
 use crate::{c_str, sys::*};
 use std::{

--- a/phper/src/modules.rs
+++ b/phper/src/modules.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_module_entry](crate::sys::zend_module_entry).
+//! Apis relate to [zend_module_entry].
 
 use crate::{
     c_str_ptr,

--- a/phper/src/objects.rs
+++ b/phper/src/objects.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_object](crate::sys::zend_object).
+//! Apis relate to [zend_object].
 
 use crate::{
     alloc::EBox,
@@ -30,7 +30,7 @@ use std::{
     ptr::null_mut,
 };
 
-/// Wrapper of [zend_object](crate::sys::zend_object).
+/// Wrapper of [zend_object].
 #[repr(transparent)]
 pub struct ZObj {
     inner: zend_object,
@@ -287,7 +287,7 @@ impl Debug for ZObj {
     }
 }
 
-/// Wrapper of [zend_object](crate::sys::zend_object).
+/// Wrapper of [zend_object].
 pub struct ZObject {
     inner: *mut ZObj,
 }
@@ -498,9 +498,9 @@ impl<T> StateObject<T> {
 impl<T: 'static> StateObject<T> {
     /// Converts into state.
     ///
-    /// Because the [zend_object](crate::sys::zend_object) is refcounted type,
+    /// Because the [zend_object] is refcounted type,
     /// therefore, you can only obtain state ownership when the refcount of the
-    /// [zend_object](crate::sys::zend_object) is `1`, otherwise, it will return
+    /// [zend_object] is `1`, otherwise, it will return
     /// `None`.
     pub fn into_state(mut self) -> Option<T> {
         unsafe {

--- a/phper/src/references.rs
+++ b/phper/src/references.rs
@@ -8,12 +8,12 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_resource](crate::sys::zend_resource).
+//! Apis relate to [zend_resource].
 
 use crate::{sys::*, values::ZVal};
 use std::fmt::{self, Debug};
 
-/// Wrapper of [zend_resource](crate::sys::zend_resource).
+/// Wrapper of [zend_resource].
 #[repr(transparent)]
 pub struct ZRef {
     inner: zend_reference,

--- a/phper/src/resources.rs
+++ b/phper/src/resources.rs
@@ -8,12 +8,12 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_resource](crate::sys::zend_resource).
+//! Apis relate to [zend_resource].
 
 use crate::sys::*;
 use std::fmt::{self, Debug};
 
-/// Wrapper of [zend_resource](crate::sys::zend_resource).
+/// Wrapper of [zend_resource].
 #[repr(transparent)]
 pub struct ZRes {
     inner: zend_resource,

--- a/phper/src/strings.rs
+++ b/phper/src/strings.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zend_string](crate::sys::zend_string).
+//! Apis relate to [zend_string].
 
 use crate::sys::*;
 use phper_alloc::ToRefOwned;
@@ -26,7 +26,7 @@ use std::{
     str::Utf8Error,
 };
 
-/// Like str, CStr for [zend_string](crate::sys::zend_string).
+/// Like str, CStr for [zend_string].
 #[repr(transparent)]
 pub struct ZStr {
     inner: zend_string,
@@ -171,7 +171,7 @@ impl ToRefOwned for ZStr {
     }
 }
 
-/// Like String, CString for [zend_string](crate::sys::zend_string).
+/// Like String, CString for [zend_string].
 pub struct ZString {
     inner: *mut ZStr,
 }

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -8,7 +8,7 @@
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
 
-//! Apis relate to [zval](crate::sys::zval).
+//! Apis relate to [zval].
 
 use crate::{
     alloc::EBox,
@@ -33,7 +33,7 @@ use std::{
     str,
 };
 
-/// Wrapper of [zend_execute_data](crate::sys::zend_execute_data).
+/// Wrapper of [zend_execute_data].
 #[repr(transparent)]
 pub struct ExecuteData {
     inner: zend_execute_data,
@@ -177,7 +177,7 @@ impl ExecuteData {
     }
 }
 
-/// Wrapper of [zval](crate::sys::zval).
+/// Wrapper of [zval].
 #[repr(transparent)]
 pub struct ZVal {
     inner: zval,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,5 +9,5 @@
 # See the Mulan PSL v2 for more details.
 
 [toolchain]
-channel = "1.65"
+channel = "1.67"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Due to `time` crate, I am very disgusted with this method of upgrading MSRV without increasing the main version number.