### PR TITLE
adding class+interface constants

### DIFF
--- a/phper-doc/doc/_06_module/_06_register_class/index.md
+++ b/phper-doc/doc/_06_module/_06_register_class/index.md
@@ -102,6 +102,18 @@ foo.add_static_method(
 ).argument(Argument::by_val("name"));
 ```
 
+## Add constants
+Interfaces can have public constants. Value can be string|int|bool|float|null.
+
+```rust,no_run
+use phper::classes::ClassEntity;
+
+let mut foo = ClassEntity::new("Foo");
+foo.add_constant("ONE", "one");
+foo.add_constant("TWO", 2);
+foo.add_constant("THREE", 3.0);
+```
+
 ## Handle state
 
 > The `ClassEntity` represents the class entry hold the state as generic type,

--- a/phper-doc/doc/_06_module/_07_register_interface/index.md
+++ b/phper-doc/doc/_06_module/_07_register_interface/index.md
@@ -72,3 +72,15 @@ foo.add_method("doSomethings").argument(Argument::by_val("name"));
 ```
 
 Note that abstract has no method body, so you don't need to add the handler to the method.
+
+## Add constants
+Interfaces can have public constants. Value can be string|int|bool|float|null.
+
+```rust,no_run
+use phper::classes::InterfaceEntity;
+
+let mut foo = InterfaceEntity::new("Foo");
+foo.add_constant("ONE", "one");
+foo.add_constant("TWO", 2);
+foo.add_constant("THREE", 3.0);
+```

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -25,6 +25,7 @@ pub fn integrate(module: &mut Module) {
     integrate_foo(module);
     integrate_i_bar(module);
     integrate_static_props(module);
+    integrate_i_constants(module);
     #[cfg(phper_major_version = "8")]
     integrate_stringable(module);
 }
@@ -34,6 +35,12 @@ fn integrate_a(module: &mut Module) {
 
     class.add_property("name", Visibility::Private, "default");
     class.add_property("number", Visibility::Private, 100);
+    class.add_constant("CST_STRING", "foo");
+    class.add_constant("CST_NULL", ());
+    class.add_constant("CST_TRUE", true);
+    class.add_constant("CST_FALSE", false);
+    class.add_constant("CST_INT", 100);
+    class.add_constant("CST_FLOAT", 3.14159);
 
     class
         .add_method("__construct", Visibility::Public, |this, arguments| {
@@ -154,6 +161,19 @@ fn integrate_i_bar(module: &mut Module) {
     interface
         .add_method("doSomethings")
         .argument(Argument::by_val("job_name"));
+
+    module.add_interface(interface);
+}
+
+fn integrate_i_constants(module: &mut Module) {
+    let mut interface = InterfaceEntity::new(r"IntegrationTest\IConstants");
+
+    interface.add_constant("CST_STRING", "foo");
+    interface.add_constant("CST_NULL", ());
+    interface.add_constant("CST_TRUE", true);
+    interface.add_constant("CST_FALSE", false);
+    interface.add_constant("CST_INT", 100);
+    interface.add_constant("CST_FLOAT", 3.14159);
 
     module.add_interface(interface);
 }

--- a/tests/integration/tests/php/classes.php
+++ b/tests/integration/tests/php/classes.php
@@ -78,3 +78,20 @@ assert_eq($foo2->current(), 'Current: 0');
 if (PHP_VERSION_ID >= 80000) {
     assert_eq(((string) (new IntegrationTest\FooString())), 'string');
 }
+
+// Test class constants
+assert_eq('foo', IntegrationTest\A::CST_STRING);
+assert_eq(null, IntegrationTest\A::CST_NULL);
+assert_true(true, IntegrationTest\A::CST_TRUE);
+assert_false(false, IntegrationTest\A::CST_FALSE);
+assert_eq(100, IntegrationTest\A::CST_INT);
+assert_eq(3.14159, IntegrationTest\A::CST_FLOAT);
+
+// Test interface constants
+assert_true(interface_exists(IntegrationTest\IConstants::class));
+assert_eq('foo', IntegrationTest\IConstants::CST_STRING);
+assert_eq(null, IntegrationTest\IConstants::CST_NULL);
+assert_true(IntegrationTest\IConstants::CST_TRUE);
+assert_false(IntegrationTest\IConstants::CST_FALSE);
+assert_eq(100, IntegrationTest\IConstants::CST_INT);
+assert_eq(3.14159, IntegrationTest\IConstants::CST_FLOAT);


### PR DESCRIPTION
* allow ClassEntity.add_constant and InterfaceEntity.add_constant, which will call zend_declare_class_constant_*
* update documentation