### PR TITLE
adding test for bind_class

### DIFF
--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -31,6 +31,7 @@ pub fn integrate(module: &mut Module) {
 
 fn integrate_a(module: &mut Module) {
     let mut class = ClassEntity::new("IntegrationTest\\A");
+    let integrate_a_class = class.bind_class();
 
     class.add_property("name", Visibility::Private, "default");
     class.add_property("number", Visibility::Private, 100);
@@ -50,6 +51,11 @@ fn integrate_a(module: &mut Module) {
             Ok::<_, phper::Error>(())
         })
         .arguments([Argument::by_val("name"), Argument::by_val("number")]);
+
+    class.add_static_method("newInstance", Visibility::Public, move |_| {
+        let object = integrate_a_class.init_object()?;
+        Ok::<_, phper::Error>(object)
+    });
 
     class.add_method("speak", Visibility::Public, |this, _arguments| {
         let name = this

--- a/tests/integration/tests/php/classes.php
+++ b/tests/integration/tests/php/classes.php
@@ -29,6 +29,11 @@ $reflection_class = new ReflectionClass(\IntegrationTest\A::class);
 $property_name = $reflection_class->getProperty("name");
 assert_true($property_name->isPrivate());
 
+// Test bind_class
+$a_instance = IntegrationTest\A::newInstance();
+assert_true($a_instance instanceof IntegrationTest\A);
+assert_eq($a_instance->speak(), "name: default, number: 100");
+
 // Test registering class;
 $foo = new \IntegrationTest\Foo();
 


### PR DESCRIPTION
Follow-up to #177 this adds a test that a ClassEntity can be bound and used to init a new object.