### PR TITLE
[breaking] add argument and return value type-hints

### DIFF
--- a/examples/complex/src/lib.rs
+++ b/examples/complex/src/lib.rs
@@ -58,7 +58,7 @@ pub fn get_module() -> Module {
     // register functions
     module
         .add_function("complex_say_hello", say_hello)
-        .argument(Argument::by_val("name"));
+        .argument(Argument::new("name"));
     module.add_function("complex_throw_exception", throw_exception);
     module.add_function("complex_get_all_ini", |_: &mut [ZVal]| {
         let mut arr = ZArray::new();
@@ -91,7 +91,7 @@ pub fn get_module() -> Module {
                 Ok(())
             },
         )
-        .argument(Argument::by_val("foo"));
+        .argument(Argument::new("foo"));
     module.add_class(foo_class);
 
     // register extra info

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -36,7 +36,7 @@ pub fn get_module() -> Module {
     // Register function `say_hello`, with one argument `name`.
     module
         .add_function("say_hello", say_hello)
-        .argument(Argument::by_val("name"));
+        .argument(Argument::new("name"));
 
     module
 }

--- a/examples/http-client/src/client.rs
+++ b/examples/http-client/src/client.rs
@@ -39,7 +39,7 @@ pub fn make_client_builder_class(client_class: ClientClass) -> ClassEntity<Clien
             *state = builder.timeout(Duration::from_millis(ms as u64));
             Ok::<_, phper::Error>(this.to_ref_owned())
         })
-        .argument(Argument::by_val("ms"));
+        .argument(Argument::new("ms"));
 
     // Inner call the `ClientBuilder::cookie_store`.
     class
@@ -50,7 +50,7 @@ pub fn make_client_builder_class(client_class: ClientClass) -> ClassEntity<Clien
             *state = builder.cookie_store(enable);
             Ok::<_, phper::Error>(this.to_ref_owned())
         })
-        .argument(Argument::by_val("enable"));
+        .argument(Argument::new("enable"));
 
     // Inner call the `ClientBuilder::build`, and wrap the result `Client` in
     // Object.
@@ -85,7 +85,7 @@ pub fn make_client_class(
             *object.as_mut_state() = Some(request_builder);
             Ok::<_, phper::Error>(object)
         })
-        .argument(Argument::by_val("url"));
+        .argument(Argument::new("url"));
 
     class
         .add_method("post", Visibility::Public, move |this, arguments| {
@@ -96,7 +96,7 @@ pub fn make_client_class(
             *object.as_mut_state() = Some(request_builder);
             Ok::<_, phper::Error>(object)
         })
-        .argument(Argument::by_val("url"));
+        .argument(Argument::new("url"));
 
     class
 }

--- a/examples/http-server/src/response.rs
+++ b/examples/http-server/src/response.rs
@@ -43,8 +43,8 @@ pub fn make_response_class() -> ClassEntity<Response<Body>> {
 
             Ok::<_, phper::Error>(())
         })
-        .argument(Argument::by_val("name"))
-        .argument(Argument::by_val("value"));
+        .argument(Argument::new("name"))
+        .argument(Argument::new("value"));
 
     // Register the end method with public visibility, accept `data` parameters.
     class
@@ -54,7 +54,7 @@ pub fn make_response_class() -> ClassEntity<Response<Body>> {
             *response.body_mut() = arguments[0].expect_z_str()?.to_bytes().to_vec().into();
             Ok::<_, phper::Error>(())
         })
-        .argument(Argument::by_val("data"));
+        .argument(Argument::new("data"));
 
     class
 }

--- a/examples/http-server/src/server.rs
+++ b/examples/http-server/src/server.rs
@@ -67,7 +67,7 @@ pub fn make_server_class(
 
             Ok::<_, phper::Error>(())
         })
-        .arguments([Argument::by_val("host"), Argument::by_val("port")]);
+        .arguments([Argument::new("host"), Argument::new("port")]);
 
     // Register the onRequest method, with public visibility, insert the handle into
     // global ON_REQUEST_HANDLERS map.
@@ -80,7 +80,7 @@ pub fn make_server_class(
             });
             Ok::<_, phper::Error>(())
         })
-        .argument(Argument::by_val("handle"));
+        .argument(Argument::new("handle"));
 
     // Register the start method, with public visibility, this method will start and
     // http server, listen on the addr, and block.

--- a/examples/logging/src/lib.rs
+++ b/examples/logging/src/lib.rs
@@ -32,7 +32,7 @@ pub fn get_module() -> Module {
             echo!("Hello, {}!", message);
             Ok(())
         })
-        .argument(Argument::by_val("message"));
+        .argument(Argument::new("message"));
 
     module
         .add_function("log_notice", |params: &mut [ZVal]| -> phper::Result<()> {
@@ -45,7 +45,7 @@ pub fn get_module() -> Module {
             notice!("Something happened: {}", message);
             Ok(())
         })
-        .argument(Argument::by_val("message"));
+        .argument(Argument::new("message"));
 
     module
         .add_function("log_warning", |params: &mut [ZVal]| -> phper::Result<()> {
@@ -58,7 +58,7 @@ pub fn get_module() -> Module {
             warning!("Something warning: {}", message);
             Ok(())
         })
-        .argument(Argument::by_val("message"));
+        .argument(Argument::new("message"));
 
     module
         .add_function("log_error", |params: &mut [ZVal]| -> phper::Result<()> {
@@ -70,7 +70,7 @@ pub fn get_module() -> Module {
             error!("Something gone failed: {}", message);
             Ok(())
         })
-        .argument(Argument::by_val("message"));
+        .argument(Argument::new("message"));
 
     module
         .add_function(
@@ -85,7 +85,7 @@ pub fn get_module() -> Module {
                 Ok(())
             },
         )
-        .argument(Argument::by_val("message"));
+        .argument(Argument::new("message"));
 
     module
 }

--- a/phper-doc/doc/_02_quick_start/_01_write_your_first_extension/index.md
+++ b/phper-doc/doc/_02_quick_start/_01_write_your_first_extension/index.md
@@ -79,7 +79,7 @@ Full example is <https://github.com/phper-framework/phper/tree/master/examples/h
        );
    
        // Register function `say_hello`, with one argument `name`.
-       module.add_function("say_hello", say_hello).argument(Argument::by_val("name"));
+       module.add_function("say_hello", say_hello).argument(Argument::new("name"));
    
        module
    }

--- a/phper-doc/doc/_02_quick_start/_02_write_a_simple_http_client/index.md
+++ b/phper-doc/doc/_02_quick_start/_02_write_a_simple_http_client/index.md
@@ -211,7 +211,7 @@ Now let's begin to finish the logic.
                *state = builder.timeout(Duration::from_millis(ms as u64));
                Ok::<_, phper::Error>(this.to_ref_owned())
            })
-           .argument(Argument::by_val("ms"));
+           .argument(Argument::new("ms"));
    
        // Inner call the `ClientBuilder::cookie_store`.
        class
@@ -222,7 +222,7 @@ Now let's begin to finish the logic.
                *state = builder.cookie_store(enable);
                Ok::<_, phper::Error>(this.to_ref_owned())
            })
-           .argument(Argument::by_val("enable"));
+           .argument(Argument::new("enable"));
    
        // Inner call the `ClientBuilder::build`, and wrap the result `Client` in
        // Object.

--- a/phper-doc/doc/_06_module/_02_register_functions/index.md
+++ b/phper-doc/doc/_06_module/_02_register_functions/index.md
@@ -80,3 +80,43 @@ pub fn get_module() -> Module {
 Here, the argument is registered as
 [`Argument::by_ref`](phper::functions::Argument::by_ref).  Therefore, the type of
 the `count` parameter is no longer long, but a reference.
+
+## Argument and return type modifiers
+
+Arguments can have type-hints, nullability and default values applied. Here we define a function that accepts
+a nullable class (in this case, an interface), and a string with a default value:
+
+```rust,no-run
+use phper::{modules::Module, php_get_module, functions::Argument, echo};
+
+#[php_get_module]
+pub fn get_module() -> Module {
+    let mut module = Module::new(
+        env!("CARGO_CRATE_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_AUTHORS"),
+    );
+
+    module.add_function("my_function", |_| -> phper::Result<()> {
+        Ok(())
+    })
+    .argument(Argument::by_val("a_class").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface"))).allow_null())
+    .argument(Argument::by_val("name").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("'my_default'").unwrap()))
+    .argument(Argument::by_val("optional_bool").with_type_hint(ArgumentTypeHint::Bool).optional());
+
+    module
+}
+```
+
+The output of `php --re` for this function would look like:
+
+```txt
+    Function [ <internal:integration> function my_function ] {
+
+      - Parameters [3] {
+        Parameter #0 [ <required> ?class_name $a_class ]
+        Parameter #1 [ <optional> string $name = 'my_default' ]
+        Parameter #2 [ <optional> bool $optional_bool = <default> ]
+      }
+    }
+```

--- a/phper-doc/doc/_06_module/_02_register_functions/index.md
+++ b/phper-doc/doc/_06_module/_02_register_functions/index.md
@@ -86,8 +86,10 @@ the `count` parameter is no longer long, but a reference.
 Arguments can have type-hints, nullability and default values applied. Here we define a function that accepts
 a nullable class (in this case, an interface), and a string with a default value:
 
-```rust,no-run
+```rust,no_run
 use phper::{modules::Module, php_get_module, functions::Argument, echo};
+use phper::types::ArgumentTypeHint;
+use std::ffi::CString;
 
 #[php_get_module]
 pub fn get_module() -> Module {

--- a/phper-doc/doc/_06_module/_02_register_functions/index.md
+++ b/phper-doc/doc/_06_module/_02_register_functions/index.md
@@ -18,7 +18,7 @@ pub fn get_module() -> Module {
         let name = arguments[0].expect_z_str()?.to_str()?;
         echo!("Hello, {}!\n", name);
         Ok(())
-    }).argument(Argument::by_val("name"));
+    }).argument(Argument::new("name"));
 
     module
 }
@@ -71,7 +71,7 @@ pub fn get_module() -> Module {
         let count = arguments[0].expect_mut_z_ref()?;
         *count.val_mut().expect_mut_long()? += 100;
         Ok(())
-    }).argument(Argument::by_ref("count"));
+    }).argument(Argument::new("count").by_ref());
 
     module
 }
@@ -101,9 +101,9 @@ pub fn get_module() -> Module {
     module.add_function("my_function", |_| -> phper::Result<()> {
         Ok(())
     })
-    .argument(Argument::by_val("a_class").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface"))).allow_null())
-    .argument(Argument::by_val("name").with_type_hint(ArgumentTypeHint::String).with_default_value("'my_default'"))
-    .argument(Argument::by_val("optional_bool").with_type_hint(ArgumentTypeHint::Bool).optional());
+    .argument(Argument::new("a_class").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface"))).allow_null())
+    .argument(Argument::new("name").with_type_hint(ArgumentTypeHint::String).with_default_value("'my_default'"))
+    .argument(Argument::new("optional_bool").with_type_hint(ArgumentTypeHint::Bool).optional());
 
     module
 }

--- a/phper-doc/doc/_06_module/_02_register_functions/index.md
+++ b/phper-doc/doc/_06_module/_02_register_functions/index.md
@@ -89,7 +89,6 @@ a nullable class (in this case, an interface), and a string with a default value
 ```rust,no_run
 use phper::{modules::Module, php_get_module, functions::Argument, echo};
 use phper::types::ArgumentTypeHint;
-use std::ffi::CString;
 
 #[php_get_module]
 pub fn get_module() -> Module {
@@ -103,7 +102,7 @@ pub fn get_module() -> Module {
         Ok(())
     })
     .argument(Argument::by_val("a_class").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface"))).allow_null())
-    .argument(Argument::by_val("name").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("'my_default'").unwrap()))
+    .argument(Argument::by_val("name").with_type_hint(ArgumentTypeHint::String).with_default_value("'my_default'"))
     .argument(Argument::by_val("optional_bool").with_type_hint(ArgumentTypeHint::Bool).optional());
 
     module

--- a/phper-doc/doc/_06_module/_06_register_class/index.md
+++ b/phper-doc/doc/_06_module/_06_register_class/index.md
@@ -102,6 +102,28 @@ foo.add_static_method(
 ).argument(Argument::by_val("name"));
 ```
 
+## Argument and return type modifiers
+
+Methods may add argument and return typehints as per functions. For example:
+
+```rust,no-run
+use phper::classes::{ClassEntity, ClassEntry, Visibility};
+use phper::functions::Argument;
+use phper::types::{ArgumentTypeHint, ReturnTypeHint},
+
+let mut foo = ClassEntity::new("Foo");
+foo.add_method(
+    "test",
+    Visibility::Public,
+    |_this, _arguments| {
+        Ok(())
+    },
+)
+.argument(Argument::by_val("a_string").with_type_hint(ArgumentTypeHint::String))
+.argument(Argument::by_val("an_interface").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface")))))
+.return_type(ReturnType::by_val(ReturnTypeHint::Bool).allow_null());
+```
+
 ## Add constants
 Interfaces can have public constants. Value can be string|int|bool|float|null.
 

--- a/phper-doc/doc/_06_module/_06_register_class/index.md
+++ b/phper-doc/doc/_06_module/_06_register_class/index.md
@@ -99,7 +99,7 @@ foo.add_static_method(
         let name = arguments[0].expect_z_str()?.to_str()?;
         Ok::<_, phper::Error>(format!("Hello, {}!\n", name))
     },
-).argument(Argument::by_val("name"));
+).argument(Argument::new("name"));
 ```
 
 ## Argument and return type modifiers
@@ -119,9 +119,9 @@ foo.add_method(
         Ok(())
     },
 )
-.argument(Argument::by_val("a_string").with_type_hint(ArgumentTypeHint::String))
-.argument(Argument::by_val("an_interface").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface"))))
-.return_type(ReturnType::by_val(ReturnTypeHint::Bool).allow_null());
+.argument(Argument::new("a_string").with_type_hint(ArgumentTypeHint::String))
+.argument(Argument::new("an_interface").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface"))))
+.return_type(ReturnType::new(ReturnTypeHint::Bool).allow_null());
 ```
 
 ## Add constants
@@ -170,8 +170,8 @@ class.add_method(
         Ok::<_, phper::Error>(())
     },
 )
-.argument(Argument::by_val("key"))
-.argument(Argument::by_val("value"));
+.argument(Argument::new("key"))
+.argument(Argument::new("value"));
 ```
 
 Equivalent to the following PHP code (hides the implementation details):

--- a/phper-doc/doc/_06_module/_06_register_class/index.md
+++ b/phper-doc/doc/_06_module/_06_register_class/index.md
@@ -106,21 +106,21 @@ foo.add_static_method(
 
 Methods may add argument and return typehints as per functions. For example:
 
-```rust,no-run
+```rust,no_run
 use phper::classes::{ClassEntity, ClassEntry, Visibility};
-use phper::functions::Argument;
-use phper::types::{ArgumentTypeHint, ReturnTypeHint},
+use phper::functions::{Argument, ReturnType};
+use phper::types::{ArgumentTypeHint, ReturnTypeHint};
 
 let mut foo = ClassEntity::new("Foo");
 foo.add_method(
     "test",
     Visibility::Public,
-    |_this, _arguments| {
+    |_this, _arguments| -> phper::Result<()> {
         Ok(())
     },
 )
 .argument(Argument::by_val("a_string").with_type_hint(ArgumentTypeHint::String))
-.argument(Argument::by_val("an_interface").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface")))))
+.argument(Argument::by_val("an_interface").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"\MyNamespace\MyInterface"))))
 .return_type(ReturnType::by_val(ReturnTypeHint::Bool).allow_null());
 ```
 

--- a/phper-doc/doc/_06_module/_07_register_interface/index.md
+++ b/phper-doc/doc/_06_module/_07_register_interface/index.md
@@ -68,7 +68,7 @@ use phper::objects::StateObj;
 use phper::values::ZVal;
 
 let mut foo = InterfaceEntity::new("Foo");
-foo.add_method("doSomethings").argument(Argument::by_val("name"));
+foo.add_method("doSomethings").argument(Argument::new("name"));
 ```
 
 Note that abstract has no method body, so you don't need to add the handler to the method.

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -484,6 +484,8 @@ zend_internal_arg_info
 phper_zend_begin_arg_with_return_type_info_ex(bool return_reference,
                                               uintptr_t required_num_args,
                                               uint32_t typ, bool allow_null) {
+(void)typ;
+(void)allow_null;
 #define static
 #define const
 #if PHP_VERSION_ID >= 70400
@@ -505,6 +507,8 @@ phper_zend_begin_arg_with_return_obj_info_ex(bool return_reference,
                                              uintptr_t required_num_args,
                                              const char* class_name,
                                              bool allow_null) {
+(void)class_name;
+(void)allow_null;
 #define static
 #define const
 #if PHP_VERSION_ID >= 80000
@@ -529,6 +533,7 @@ zend_internal_arg_info phper_zend_arg_info_with_type(bool pass_by_ref,
                                                     uint32_t type_hint,
                                                     bool allow_null,
                                                     const char *default_value) {
+(void)default_value;
 #if PHP_VERSION_ID >= 80000
     zend_internal_arg_info info[] = {
         ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, type_hint, allow_null, default_value)
@@ -546,6 +551,10 @@ zend_internal_arg_info phper_zend_arg_obj_info(bool pass_by_ref,
                                                const char *name,
                                                const char *class_name,
                                                bool allow_null) {
+// suppress "unused parameter" warnings.
+(void)name;
+(void)class_name;
+(void)allow_null;
 #if PHP_VERSION_ID >= 80000
     zend_internal_arg_info info[] = {
         ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, class_name, allow_null, NULL)

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -38,6 +38,14 @@ phper_init_class_entry_handler(zend_class_entry *class_ce, void *argument);
 #define IS_NEVER 0x1B
 #endif
 
+#ifndef IS_ITERABLE
+#define IS_ITERABLE 0x1C
+#endif
+
+#ifndef IS_VOID
+#define IS_VOID 0x1D
+#endif
+
 // ==================================================
 // zval apis:
 // ==================================================
@@ -500,10 +508,8 @@ phper_zend_begin_arg_with_return_obj_info_ex(bool return_reference,
 #define static
 #define const
 #if PHP_VERSION_ID >= 70400
-    ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(info, return_reference,
-                                           required_num_args,
-                                           class_name, allow_null)
-#elif PHP_VERSION_ID >= 70200
+    ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(info, return_reference, required_num_args, class_name, allow_null)
+#else
     ZEND_BEGIN_ARG_INFO_EX(info, 0, return_reference, required_num_args)
 #endif
     ZEND_END_ARG_INFO()
@@ -527,14 +533,9 @@ zend_internal_arg_info phper_zend_arg_info_with_type(bool pass_by_ref,
     zend_internal_arg_info info[] = {
         ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, type_hint, allow_null, default_value)
     };
-#elif PHP_VERSION_ID >= 70200
+#elif PHP_VERSION_ID >= 70000
     zend_internal_arg_info info[] = {
         ZEND_ARG_TYPE_INFO(pass_by_ref, name, type_hint, allow_null)
-    };
-#else
-    // PHP 7.0 and below: fallback
-    zend_internal_arg_info info[] = {
-        ZEND_ARG_INFO(pass_by_ref, name)
     };
 #endif
     info[0].name = name;
@@ -561,9 +562,7 @@ zend_internal_arg_info phper_zend_arg_obj_info(bool pass_by_ref,
 #else
     zend_internal_arg_info info = {
         .name = name,
-        .type = 0,
         .pass_by_reference = pass_by_ref,
-        .is_variadic = 0
     };
     return info;
 #endif

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -511,14 +511,15 @@ zend_internal_arg_info phper_zend_arg_info(bool pass_by_ref, const char *name) {
 zend_internal_arg_info phper_zend_arg_info_with_type(bool pass_by_ref,
                                                     const char *name,
                                                     uint32_t type_hint,
-                                                    bool allow_null) {
+                                                    bool allow_null,
+                                                    const char *default_value) {
 #if PHP_VERSION_ID >= 70200
     zend_internal_arg_info info[] = {
-        ZEND_ARG_TYPE_INFO(pass_by_ref, , type_hint, allow_null)
+        ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(pass_by_ref, , type_hint, allow_null, default_value)
     };
 #else
     zend_internal_arg_info info[] = {
-        ZEND_ARG_TYPE_INFO(pass_by_ref, , type_hint, NULL, allow_null)
+        ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(pass_by_ref, , type_hint, NULL, allow_null, default_value)
     };
 #endif
     info[0].name = name;

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -485,3 +485,31 @@ zend_internal_arg_info phper_zend_arg_info(bool pass_by_ref, const char *name) {
     info[0].name = name;
     return info[0];
 }
+
+zend_internal_arg_info phper_zend_arg_info_with_type(bool pass_by_ref,
+                                                    const char *name,
+                                                    uint32_t type_hint,
+                                                    bool allow_null) {
+#if PHP_VERSION_ID >= 70200
+    zend_internal_arg_info info[] = {
+        ZEND_ARG_TYPE_INFO(pass_by_ref, , type_hint, allow_null)
+    };
+#else
+    zend_internal_arg_info info[] = {
+        ZEND_ARG_TYPE_INFO(pass_by_ref, , type_hint, NULL, allow_null)
+    };
+#endif
+    info[0].name = name;
+    return info[0];
+}
+
+zend_internal_arg_info phper_zend_arg_obj_info(bool pass_by_ref,
+                                              const char *name,
+                                              const char *class_name,
+                                              bool allow_null) {
+    zend_internal_arg_info info[] = {
+        ZEND_ARG_OBJ_INFO(pass_by_ref, , class_name, allow_null)
+    };
+    info[0].name = name;
+    return info[0];
+}

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -480,6 +480,28 @@ phper_zend_begin_arg_with_return_type_info_ex(bool return_reference,
 #undef const
 }
 
+zend_internal_arg_info
+phper_zend_begin_arg_with_return_obj_info_ex(bool return_reference,
+                                             uintptr_t required_num_args,
+                                             const char* class_name,
+                                             bool allow_null) {
+#define static
+#define const
+#if PHP_VERSION_ID >= 70200
+    ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(info, return_reference,
+                                            required_num_args,
+                                            class_name, allow_null)
+#else
+    ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(
+        info, return_reference, required_num_args,
+        class_name, NULL, allow_null)
+#endif
+    ZEND_END_ARG_INFO()
+    return info[0];
+#undef static
+#undef const
+}
+
 zend_internal_arg_info phper_zend_arg_info(bool pass_by_ref, const char *name) {
     zend_internal_arg_info info[] = {ZEND_ARG_INFO(pass_by_ref, )};
     info[0].name = name;

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -507,7 +507,7 @@ phper_zend_begin_arg_with_return_obj_info_ex(bool return_reference,
                                              bool allow_null) {
 #define static
 #define const
-#if PHP_VERSION_ID >= 70400
+#if PHP_VERSION_ID >= 80000
     ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(info, return_reference, required_num_args, class_name, allow_null)
 #else
     ZEND_BEGIN_ARG_INFO_EX(info, 0, return_reference, required_num_args)
@@ -529,7 +529,7 @@ zend_internal_arg_info phper_zend_arg_info_with_type(bool pass_by_ref,
                                                     uint32_t type_hint,
                                                     bool allow_null,
                                                     const char *default_value) {
-#if PHP_VERSION_ID >= 70400
+#if PHP_VERSION_ID >= 80000
     zend_internal_arg_info info[] = {
         ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, type_hint, allow_null, default_value)
     };
@@ -546,7 +546,7 @@ zend_internal_arg_info phper_zend_arg_obj_info(bool pass_by_ref,
                                                const char *name,
                                                const char *class_name,
                                                bool allow_null) {
-#if PHP_VERSION_ID >= 70400
+#if PHP_VERSION_ID >= 80000
     zend_internal_arg_info info[] = {
         ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, class_name, allow_null, NULL)
     };

--- a/phper/src/classes.rs
+++ b/phper/src/classes.rs
@@ -30,6 +30,7 @@ use std::{
     marker::PhantomData,
     mem::{ManuallyDrop, replace, size_of, zeroed},
     os::raw::c_int,
+    ptr,
     ptr::null_mut,
     rc::Rc,
     slice,
@@ -48,6 +49,7 @@ pub fn array_access_class<'a>() -> &'a ClassEntry {
 }
 
 /// Wrapper of [zend_class_entry].
+#[derive(Clone)]
 #[repr(transparent)]
 pub struct ClassEntry {
     inner: zend_class_entry,
@@ -220,6 +222,14 @@ impl Debug for ClassEntry {
             .finish()
     }
 }
+
+impl PartialEq for ClassEntry {
+    fn eq(&self, other: &Self) -> bool {
+        ptr::eq(self as *const _, other as *const _)
+    }
+}
+
+impl Eq for ClassEntry {}
 
 #[allow(clippy::useless_conversion)]
 fn find_global_class_entry_ptr(name: impl AsRef<str>) -> *mut zend_class_entry {

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -220,10 +220,9 @@ impl FunctionEntry {
                             ))
                         }
                     }
-                    #[allow(clippy::absurd_extreme_comparisons)]
                     ReturnTypeHint::Never => {
                         if PHP_MAJOR_VERSION < 8
-                            || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION <= 1)
+                            || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION < 2)
                         {
                             None
                         } else {

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -192,18 +192,22 @@ impl FunctionEntry {
                         IS_OBJECT,
                         return_type.allow_null,
                     )),
-                    ReturnTypeHint::Callable => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        IS_CALLABLE,
-                        return_type.allow_null,
-                    )),
-                    ReturnTypeHint::Iterable => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        IS_ITERABLE,
-                        return_type.allow_null,
-                    )),
+                    ReturnTypeHint::Callable => {
+                        Some(phper_zend_begin_arg_with_return_type_info_ex(
+                            return_type.ret_by_ref,
+                            require_arg_count,
+                            IS_CALLABLE,
+                            return_type.allow_null,
+                        ))
+                    }
+                    ReturnTypeHint::Iterable => {
+                        Some(phper_zend_begin_arg_with_return_type_info_ex(
+                            return_type.ret_by_ref,
+                            require_arg_count,
+                            IS_ITERABLE,
+                            return_type.allow_null,
+                        ))
+                    }
                     ReturnTypeHint::Mixed => {
                         if PHP_MAJOR_VERSION < 8 {
                             None
@@ -217,7 +221,9 @@ impl FunctionEntry {
                         }
                     }
                     ReturnTypeHint::Never => {
-                        if PHP_MAJOR_VERSION < 8 || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION <= 1) {
+                        if PHP_MAJOR_VERSION < 8
+                            || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION <= 1)
+                        {
                             None
                         } else {
                             Some(phper_zend_begin_arg_with_return_type_info_ex(
@@ -249,10 +255,10 @@ impl FunctionEntry {
                 None
             };
 
-            infos.push(return_info.unwrap_or_else(|| {
-                phper_zend_begin_arg_info_ex(false, require_arg_count)
-            }));
-
+            infos.push(
+                return_info
+                    .unwrap_or_else(|| phper_zend_begin_arg_info_ex(false, require_arg_count)),
+            );
 
             for arg in arguments {
                 let default_value_ptr = arg
@@ -262,57 +268,105 @@ impl FunctionEntry {
                     .unwrap_or(std::ptr::null());
                 let arg_info = if let Some(ref type_hint) = arg.type_hint {
                     match type_hint {
-                        ArgumentTypeHint::Null => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_NULL, true, default_value_ptr)
-                        ),
-                        ArgumentTypeHint::Bool => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), _IS_BOOL, arg.nullable, default_value_ptr)
-                        ),
-                        ArgumentTypeHint::Int => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_LONG, arg.nullable, default_value_ptr)
-                        ),
-                        ArgumentTypeHint::Float => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_DOUBLE, arg.nullable, default_value_ptr)
-                        ),
-                        ArgumentTypeHint::String => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_STRING, arg.nullable, default_value_ptr)
-                        ),
-                        ArgumentTypeHint::Array => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_ARRAY, arg.nullable, default_value_ptr)
-                        ),
+                        ArgumentTypeHint::Null => Some(phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            IS_NULL,
+                            true,
+                            default_value_ptr,
+                        )),
+                        ArgumentTypeHint::Bool => Some(phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            _IS_BOOL,
+                            arg.nullable,
+                            default_value_ptr,
+                        )),
+                        ArgumentTypeHint::Int => Some(phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            IS_LONG,
+                            arg.nullable,
+                            default_value_ptr,
+                        )),
+                        ArgumentTypeHint::Float => Some(phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            IS_DOUBLE,
+                            arg.nullable,
+                            default_value_ptr,
+                        )),
+                        ArgumentTypeHint::String => Some(phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            IS_STRING,
+                            arg.nullable,
+                            default_value_ptr,
+                        )),
+                        ArgumentTypeHint::Array => Some(phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            IS_ARRAY,
+                            arg.nullable,
+                            default_value_ptr,
+                        )),
                         ArgumentTypeHint::Object => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_OBJECT, arg.nullable, std::ptr::null()) //default value not supported
+                            phper_zend_arg_info_with_type(
+                                arg.pass_by_ref,
+                                arg.name.as_ptr(),
+                                IS_OBJECT,
+                                arg.nullable,
+                                std::ptr::null(),
+                            ), // default value not supported
                         ),
                         ArgumentTypeHint::Callable => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_CALLABLE, arg.nullable, std::ptr::null()) //default value not supported
+                            phper_zend_arg_info_with_type(
+                                arg.pass_by_ref,
+                                arg.name.as_ptr(),
+                                IS_CALLABLE,
+                                arg.nullable,
+                                std::ptr::null(),
+                            ), // default value not supported
                         ),
-                        ArgumentTypeHint::Iterable => Some(
-                            phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_ITERABLE, arg.nullable, default_value_ptr)
-                        ),
+                        ArgumentTypeHint::Iterable => Some(phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            IS_ITERABLE,
+                            arg.nullable,
+                            default_value_ptr,
+                        )),
                         ArgumentTypeHint::Mixed => {
                             if PHP_MAJOR_VERSION < 8 {
                                 None
                             } else {
-                                Some(phper_zend_arg_info_with_type(arg.pass_by_ref, arg.name.as_ptr(), IS_MIXED, true, default_value_ptr))
+                                Some(phper_zend_arg_info_with_type(
+                                    arg.pass_by_ref,
+                                    arg.name.as_ptr(),
+                                    IS_MIXED,
+                                    true,
+                                    default_value_ptr,
+                                ))
                             }
-                        },
+                        }
                         ArgumentTypeHint::ClassEntry(class_name) => {
-                            let c_class_name = CString::new(class_name.clone()).expect("CString::new failed");
+                            let c_class_name =
+                                CString::new(class_name.clone()).expect("CString::new failed");
                             Some(phper_zend_arg_obj_info(
                                 arg.pass_by_ref,
                                 arg.name.as_ptr(),
                                 c_class_name.as_ptr(),
-                                arg.nullable
+                                arg.nullable,
                             ))
-                        },
+                        }
                     }
                 } else {
                     None
                 };
 
-                infos.push(arg_info.unwrap_or_else(|| {
-                    phper_zend_arg_info(arg.pass_by_ref, arg.name.as_ptr())
-                }));
+                infos
+                    .push(arg_info.unwrap_or_else(|| {
+                        phper_zend_arg_info(arg.pass_by_ref, arg.name.as_ptr())
+                    }));
             }
 
             infos.push(zeroed::<zend_internal_arg_info>());
@@ -540,7 +594,8 @@ impl Argument {
         self
     }
 
-    /// Argument default value. Example: "'a-string'", "A_CONST", "42", "[0=>'zero']"
+    /// Argument default value. Example: "'a-string'", "A_CONST", "42",
+    /// "[0=>'zero']"
     pub fn with_default_value(mut self, default_value: CString) -> Self {
         self.default_value = Some(default_value);
         self.required = false; // arg with default value does not count towards required arg count

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -220,6 +220,7 @@ impl FunctionEntry {
                             ))
                         }
                     }
+                    #[allow(clippy::absurd_extreme_comparisons)]
                     ReturnTypeHint::Never => {
                         if PHP_MAJOR_VERSION < 8
                             || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION <= 1)

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -518,8 +518,8 @@ pub struct Argument {
 }
 
 impl Argument {
-    /// Indicate the argument is pass by value.
-    pub fn by_val(name: impl Into<String>) -> Self {
+    /// Create a new argument with default values
+    pub fn new(name: impl Into<String>) -> Self {
         let name = ensure_end_with_zero(name);
         Self {
             name,
@@ -531,43 +531,10 @@ impl Argument {
         }
     }
 
-    /// Indicate the argument is pass by reference.
-    pub fn by_ref(name: impl Into<String>) -> Self {
-        let name = ensure_end_with_zero(name);
-        Self {
-            name,
-            type_hint: None,
-            pass_by_ref: true,
-            required: true,
-            nullable: false,
-            default_value: None,
-        }
-    }
-
-    /// Indicate the argument is pass by value and is optional.
-    pub fn by_val_optional(name: impl Into<String>) -> Self {
-        let name = ensure_end_with_zero(name);
-        Self {
-            name,
-            type_hint: None,
-            pass_by_ref: false,
-            required: false,
-            nullable: false,
-            default_value: None,
-        }
-    }
-
-    /// Indicate the argument is pass by reference nad is optional.
-    pub fn by_ref_optional(name: impl Into<String>) -> Self {
-        let name = ensure_end_with_zero(name);
-        Self {
-            name,
-            type_hint: None,
-            pass_by_ref: true,
-            required: false,
-            nullable: false,
-            default_value: None,
-        }
+    /// Indicate the argument is passed by reference
+    pub fn by_ref(mut self) -> Self {
+        self.pass_by_ref = true;
+        self
     }
 
     /// Add a type-hint to the argument
@@ -582,13 +549,7 @@ impl Argument {
         self
     }
 
-    /// Argument is required (also see by_*<ref|val>)
-    pub fn required(mut self) -> Self {
-        self.required = true;
-        self
-    }
-
-    /// Argument is optional (also see by_<ref|val>_optional)
+    /// Argument is optional
     pub fn optional(mut self) -> Self {
         self.required = false;
         self
@@ -614,7 +575,7 @@ pub struct ReturnType {
 impl ReturnType {
     /// Indicate the return type is return by value.
     #[inline]
-    pub fn by_val(type_hint: ReturnTypeHint) -> Self {
+    pub fn new(type_hint: ReturnTypeHint) -> Self {
         Self {
             type_hint,
             ret_by_ref: false,
@@ -624,12 +585,9 @@ impl ReturnType {
 
     /// Indicate the return type is return by reference.
     #[inline]
-    pub fn by_ref(type_hint: ReturnTypeHint) -> Self {
-        Self {
-            type_hint,
-            ret_by_ref: true,
-            allow_null: false,
-        }
+    pub fn by_ref(mut self) -> Self {
+        self.ret_by_ref = true;
+        self
     }
 
     /// Indicate the return type can be null.
@@ -640,6 +598,7 @@ impl ReturnType {
     }
 
     /// Add a type-hint to the return type
+    #[inline]
     pub fn with_type_hint(mut self, type_hint: ReturnTypeHint) -> Self {
         self.type_hint = type_hint;
         self

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -540,10 +540,10 @@ impl Argument {
         self
     }
 
-    /// Argument default value (always a String)
+    /// Argument default value. Example: "'a-string'", "A_CONST", "42", "[0=>'zero']"
     pub fn with_default_value(mut self, default_value: CString) -> Self {
         self.default_value = Some(default_value);
-        self.required = false; // important!
+        self.required = false; // arg with default value does not count towards required arg count
         self
     }
 }

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -596,7 +596,8 @@ impl Argument {
 
     /// Argument default value. Example: "'a-string'", "A_CONST", "42",
     /// "[0=>'zero']"
-    pub fn with_default_value(mut self, default_value: CString) -> Self {
+    pub fn with_default_value(mut self, default_value: impl Into<String>) -> Self {
+        let default_value = ensure_end_with_zero(default_value);
         self.default_value = Some(default_value);
         self.required = false; // arg with default value does not count towards required arg count
         self

--- a/phper/src/modules.rs
+++ b/phper/src/modules.rs
@@ -51,14 +51,14 @@ unsafe extern "C" fn module_startup(_type: c_int, module_number: c_int) -> c_int
             constant.register(module_number);
         }
 
+        for interface_entity in &module.interface_entities {
+            interface_entity.init();
+        }
+
         for class_entity in &module.class_entities {
             let ce = class_entity.init();
             class_entity.declare_properties(ce);
             module.handler_map.extend(class_entity.handler_map());
-        }
-
-        for interface_entity in &module.interface_entities {
-            interface_entity.init();
         }
 
         if let Some(f) = take(&mut module.module_init) {

--- a/phper/src/types.rs
+++ b/phper/src/types.rs
@@ -10,9 +10,7 @@
 
 //! Apis relate to PHP types.
 
-use crate::{
-    sys::*,
-};
+use crate::sys::*;
 use derive_more::From;
 use std::{
     ffi::CStr,

--- a/phper/src/types.rs
+++ b/phper/src/types.rs
@@ -272,9 +272,7 @@ pub enum ReturnTypeHint {
     Mixed,
     /// ClassEntry typehint (class, interface)
     ClassEntry(String),
-    /// self typehint
-    _Self,
-    /// never typehint (8.2+)
+    /// never typehint (8.1+)
     Never,
     /// void typehint
     Void,

--- a/phper/src/types.rs
+++ b/phper/src/types.rs
@@ -11,7 +11,6 @@
 //! Apis relate to PHP types.
 
 use crate::{
-    classes::ClassEntry,
     sys::*,
 };
 use derive_more::From;
@@ -247,9 +246,9 @@ pub enum TypeHint {
     /// void typehint
     Void,
     /// self typehint
-    This,
+    _Self,
+    /// ClassEntry typehint (class, interface)
+    ClassEntry(String),
     /// never typehint (php 8.1+)
     Never,
-    /// class entry typehint
-    ClassEntry(ClassEntry),
 }

--- a/phper/src/types.rs
+++ b/phper/src/types.rs
@@ -10,7 +10,10 @@
 
 //! Apis relate to PHP types.
 
-use crate::sys::*;
+use crate::{
+    classes::ClassEntry,
+    sys::*,
+};
 use derive_more::From;
 use std::{
     ffi::CStr,
@@ -216,4 +219,37 @@ impl From<&[u8]> for Scalar {
     fn from(b: &[u8]) -> Self {
         Self::Bytes(b.to_owned())
     }
+}
+
+/// Wrapper of PHP typehints, used for arguments and return types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeHint {
+    /// null typehint
+    Null,
+    /// bool typehint
+    Bool,
+    /// int typehint
+    Int,
+    /// float typehint
+    Float,
+    /// string typehint
+    String,
+    /// array typehint
+    Array,
+    /// object typehint
+    Object,
+    /// callable typehint
+    Callable,
+    /// iterable typehint
+    Iterable,
+    /// mixed typehint (php 8.0+)
+    Mixed,
+    /// void typehint
+    Void,
+    /// self typehint
+    This,
+    /// never typehint (php 8.1+)
+    Never,
+    /// class entry typehint
+    ClassEntry(ClassEntry),
 }

--- a/phper/src/types.rs
+++ b/phper/src/types.rs
@@ -220,9 +220,9 @@ impl From<&[u8]> for Scalar {
     }
 }
 
-/// Wrapper of PHP typehints, used for arguments and return types.
+/// PHP argument typehints
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TypeHint {
+pub enum ArgumentTypeHint {
     /// null typehint
     Null,
     /// bool typehint
@@ -243,12 +243,39 @@ pub enum TypeHint {
     Iterable,
     /// mixed typehint (php 8.0+)
     Mixed,
-    /// void typehint
-    Void,
-    /// self typehint
-    _Self,
     /// ClassEntry typehint (class, interface)
     ClassEntry(String),
-    /// never typehint (php 8.1+)
+}
+
+/// PHP return typehints
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReturnTypeHint {
+    /// null typehint
+    Null,
+    /// bool typehint
+    Bool,
+    /// int typehint
+    Int,
+    /// float typehint
+    Float,
+    /// string typehint
+    String,
+    /// array typehint
+    Array,
+    /// object typehint
+    Object,
+    /// callable typehint
+    Callable,
+    /// iterable typehint
+    Iterable,
+    /// mixed typehint (php 8.0+)
+    Mixed,
+    /// ClassEntry typehint (class, interface)
+    ClassEntry(String),
+    /// self typehint
+    _Self,
+    /// never typehint (8.2+)
     Never,
+    /// void typehint
+    Void,
 }

--- a/tests/integration/src/arguments.rs
+++ b/tests/integration/src/arguments.rs
@@ -22,7 +22,7 @@ fn integrate_arguments(module: &mut Module) {
         .add_function("integrate_arguments_null", |arguments: &mut [ZVal]| {
             arguments[0].expect_null()
         })
-        .argument(Argument::by_val("a"));
+        .argument(Argument::new("a"));
 
     module
         .add_function(
@@ -34,13 +34,13 @@ fn integrate_arguments(module: &mut Module) {
                 Ok(a + b)
             },
         )
-        .arguments([Argument::by_val("a"), Argument::by_val("b")]);
+        .arguments([Argument::new("a"), Argument::new("b")]);
 
     module
         .add_function("integrate_arguments_double", |arguments: &mut [ZVal]| {
             arguments[0].expect_double()
         })
-        .argument(Argument::by_val("a"));
+        .argument(Argument::new("a"));
 
     module
         .add_function(
@@ -52,8 +52,8 @@ fn integrate_arguments(module: &mut Module) {
                 Ok(format!("{}, {}", a, b))
             },
         )
-        .argument(Argument::by_val("a"))
-        .argument(Argument::by_val("b"));
+        .argument(Argument::new("a"))
+        .argument(Argument::new("b"));
 
     module
         .add_function(
@@ -66,7 +66,7 @@ fn integrate_arguments(module: &mut Module) {
                 Ok(b)
             },
         )
-        .argument(Argument::by_val("a"));
+        .argument(Argument::new("a"));
 
     module
         .add_function(
@@ -78,7 +78,7 @@ fn integrate_arguments(module: &mut Module) {
                 Ok(a)
             },
         )
-        .argument(Argument::by_val("a"));
+        .argument(Argument::new("a"));
 
     module
         .add_function(
@@ -93,6 +93,6 @@ fn integrate_arguments(module: &mut Module) {
                 Ok(format!("{}: {}", a, b))
             },
         )
-        .argument(Argument::by_val("a"))
-        .argument(Argument::by_val_optional("b"));
+        .argument(Argument::new("a"))
+        .argument(Argument::new("b").optional());
 }

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -98,21 +98,24 @@ fn integrate_foo(module: &mut Module) {
         .add_method("key", Visibility::Public, |this, _arguments| {
             let state = this.as_state();
             Ok::<_, phper::Error>(state.position as i64)
-        }).return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
 
     class
         .add_method("next", Visibility::Public, |this, _arguments| {
             let state = this.as_mut_state();
             state.position += 1;
             Ok::<_, Infallible>(())
-        }).return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
 
     class
         .add_method("rewind", Visibility::Public, |this, _arguments| {
             let state = this.as_mut_state();
             state.position = 0;
             Ok::<_, Infallible>(())
-        }).return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
 
     class
         .add_method("valid", Visibility::Public, |this, _arguments| {

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -203,9 +203,7 @@ fn integrate_static_props(module: &mut Module) {
 
 #[cfg(phper_major_version = "8")]
 fn integrate_stringable(module: &mut Module) {
-    use phper::functions::ReturnType;
-    use phper::types::ReturnTypeHint;
-
+    use phper::{functions::ReturnType, types::ReturnTypeHint};
 
     let mut cls = ClassEntity::new(r"IntegrationTest\FooString");
     cls.implements(|| ClassEntry::from_globals("Stringable").unwrap());

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -16,6 +16,7 @@ use phper::{
     functions::Argument,
     modules::Module,
     values::ZVal,
+    types::ReturnTypeHint,
 };
 use std::{collections::HashMap, convert::Infallible};
 
@@ -210,6 +211,6 @@ fn integrate_stringable(module: &mut Module) {
     cls.add_method("__toString", Visibility::Public, |_this, _: &mut [ZVal]| {
         phper::ok("string")
     })
-    .return_type(ReturnType::by_val(TypeInfo::STRING));
+    .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
     module.add_class(cls);
 }

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -15,7 +15,6 @@ use phper::{
     },
     functions::Argument,
     modules::Module,
-    types::ReturnTypeHint,
     values::ZVal,
 };
 use std::{collections::HashMap, convert::Infallible};
@@ -205,6 +204,8 @@ fn integrate_static_props(module: &mut Module) {
 #[cfg(phper_major_version = "8")]
 fn integrate_stringable(module: &mut Module) {
     use phper::functions::ReturnType;
+    use phper::types::ReturnTypeHint;
+
 
     let mut cls = ClassEntity::new(r"IntegrationTest\FooString");
     cls.implements(|| ClassEntry::from_globals("Stringable").unwrap());

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -204,13 +204,13 @@ fn integrate_static_props(module: &mut Module) {
 
 #[cfg(phper_major_version = "8")]
 fn integrate_stringable(module: &mut Module) {
-    use phper::{functions::ReturnType, types::TypeInfo};
+    use phper::{functions::ReturnType};
 
     let mut cls = ClassEntity::new(r"IntegrationTest\FooString");
     cls.implements(|| ClassEntry::from_globals("Stringable").unwrap());
     cls.add_method("__toString", Visibility::Public, |_this, _: &mut [ZVal]| {
         phper::ok("string")
     })
-    .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
+    .return_type(ReturnType::by_val(ReturnTypeHint::String));
     module.add_class(cls);
 }

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -15,8 +15,8 @@ use phper::{
     },
     functions::Argument,
     modules::Module,
-    values::ZVal,
     types::ReturnTypeHint,
+    values::ZVal,
 };
 use std::{collections::HashMap, convert::Infallible};
 
@@ -204,7 +204,7 @@ fn integrate_static_props(module: &mut Module) {
 
 #[cfg(phper_major_version = "8")]
 fn integrate_stringable(module: &mut Module) {
-    use phper::{functions::ReturnType};
+    use phper::functions::ReturnType;
 
     let mut cls = ClassEntity::new(r"IntegrationTest\FooString");
     cls.implements(|| ClassEntry::from_globals("Stringable").unwrap());

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -51,7 +51,7 @@ fn integrate_a(module: &mut Module) {
             this.set_property("number", ZVal::from(number));
             Ok::<_, phper::Error>(())
         })
-        .arguments([Argument::by_val("name"), Argument::by_val("number")]);
+        .arguments([Argument::new("name"), Argument::new("number")]);
 
     class.add_static_method("newInstance", Visibility::Public, move |_| {
         let object = integrate_a_class.init_object()?;
@@ -92,14 +92,14 @@ fn integrate_foo(module: &mut Module) {
             let state = this.as_state();
             Ok::<_, phper::Error>(format!("Current: {}", state.position))
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
+        .return_type(ReturnType::new(ReturnTypeHint::Mixed));
 
     class
         .add_method("key", Visibility::Public, |this, _arguments| {
             let state = this.as_state();
             Ok::<_, phper::Error>(state.position as i64)
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
+        .return_type(ReturnType::new(ReturnTypeHint::Mixed));
 
     class
         .add_method("next", Visibility::Public, |this, _arguments| {
@@ -107,7 +107,7 @@ fn integrate_foo(module: &mut Module) {
             state.position += 1;
             Ok::<_, Infallible>(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
 
     class
         .add_method("rewind", Visibility::Public, |this, _arguments| {
@@ -115,14 +115,14 @@ fn integrate_foo(module: &mut Module) {
             state.position = 0;
             Ok::<_, Infallible>(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
 
     class
         .add_method("valid", Visibility::Public, |this, _arguments| {
             let state = this.as_state();
             Ok::<_, Infallible>(state.position < 3)
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Bool));
+        .return_type(ReturnType::new(ReturnTypeHint::Bool));
 
     // Implement ArrayAccess interface.
     class
@@ -131,8 +131,8 @@ fn integrate_foo(module: &mut Module) {
             let state = this.as_state();
             Ok::<_, phper::Error>(state.array.contains_key(&offset))
         })
-        .argument(Argument::by_val("offset").with_type_hint(ArgumentTypeHint::Mixed))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Bool));
+        .argument(Argument::new("offset").with_type_hint(ArgumentTypeHint::Mixed))
+        .return_type(ReturnType::new(ReturnTypeHint::Bool));
 
     class
         .add_method("offsetGet", Visibility::Public, |this, arguments| {
@@ -141,8 +141,8 @@ fn integrate_foo(module: &mut Module) {
             let val = state.array.get_mut(&offset).map(|val| val.ref_clone());
             Ok::<_, phper::Error>(val)
         })
-        .argument(Argument::by_val("offset").with_type_hint(ArgumentTypeHint::Mixed))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
+        .argument(Argument::new("offset").with_type_hint(ArgumentTypeHint::Mixed))
+        .return_type(ReturnType::new(ReturnTypeHint::Mixed));
 
     class
         .add_method("offsetSet", Visibility::Public, |this, arguments| {
@@ -153,10 +153,10 @@ fn integrate_foo(module: &mut Module) {
             Ok::<_, phper::Error>(())
         })
         .arguments([
-            Argument::by_val("offset").with_type_hint(ArgumentTypeHint::Mixed),
-            Argument::by_val("value").with_type_hint(ArgumentTypeHint::Mixed),
+            Argument::new("offset").with_type_hint(ArgumentTypeHint::Mixed),
+            Argument::new("value").with_type_hint(ArgumentTypeHint::Mixed),
         ])
-        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
 
     class
         .add_method("offsetUnset", Visibility::Public, |this, arguments| {
@@ -165,8 +165,8 @@ fn integrate_foo(module: &mut Module) {
             state.array.remove(&offset);
             Ok::<_, phper::Error>(())
         })
-        .argument(Argument::by_val("offset").with_type_hint(ArgumentTypeHint::Mixed))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        .argument(Argument::new("offset").with_type_hint(ArgumentTypeHint::Mixed))
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
 
     module.add_class(class);
 }
@@ -179,7 +179,7 @@ fn integrate_i_bar(module: &mut Module) {
 
     interface
         .add_method("doSomethings")
-        .argument(Argument::by_val("job_name"));
+        .argument(Argument::new("job_name"));
 
     module.add_interface(interface);
 }
@@ -218,7 +218,7 @@ fn integrate_static_props(module: &mut Module) {
                 .set_static_property("foo1", params[0].to_owned());
             phper::ok(foo1)
         })
-        .argument(Argument::by_val("val"));
+        .argument(Argument::new("val"));
 
     module.add_class(class);
 }
@@ -232,6 +232,6 @@ fn integrate_stringable(module: &mut Module) {
     cls.add_method("__toString", Visibility::Public, |_this, _: &mut [ZVal]| {
         phper::ok("string")
     })
-    .return_type(ReturnType::by_val(ReturnTypeHint::String));
+    .return_type(ReturnType::new(ReturnTypeHint::String));
     module.add_class(cls);
 }

--- a/tests/integration/src/functions.rs
+++ b/tests/integration/src/functions.rs
@@ -41,7 +41,7 @@ pub fn integrate(module: &mut Module) {
                 }
             },
         )
-        .argument(Argument::by_val("fn"));
+        .argument(Argument::new("fn"));
 
     module.add_function(
         "integrate_functions_throw_error_exception",

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -21,6 +21,7 @@ mod objects;
 mod references;
 mod strings;
 mod values;
+mod typehints;
 
 use phper::{modules::Module, php_get_module};
 
@@ -43,6 +44,7 @@ pub fn get_module() -> Module {
     ini::integrate(&mut module);
     errors::integrate(&mut module);
     references::integrate(&mut module);
+    typehints::integrate(&mut module);
 
     module
 }

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -20,8 +20,8 @@ mod ini;
 mod objects;
 mod references;
 mod strings;
-mod values;
 mod typehints;
+mod values;
 
 use phper::{modules::Module, php_get_module};
 

--- a/tests/integration/src/objects.rs
+++ b/tests/integration/src/objects.rs
@@ -94,7 +94,7 @@ pub fn integrate(module: &mut Module) {
                 Ok(())
             },
         )
-        .argument(Argument::by_val("obj"));
+        .argument(Argument::new("obj"));
 
     module
         .add_function(
@@ -125,7 +125,7 @@ pub fn integrate(module: &mut Module) {
                 Ok(())
             },
         )
-        .argument(Argument::by_val("obj"));
+        .argument(Argument::new("obj"));
 
     module.add_function("integrate_objects_set_props", |_| {
         let mut o = ZObject::new_by_std_class();

--- a/tests/integration/src/references.rs
+++ b/tests/integration/src/references.rs
@@ -24,5 +24,5 @@ pub fn integrate(module: &mut Module) {
 
             Ok::<_, phper::Error>(())
         })
-        .arguments([Argument::by_ref("foo"), Argument::by_ref("bar")]);
+        .arguments([Argument::new("foo").by_ref(), Argument::new("bar").by_ref()]);
 }

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -29,46 +29,46 @@ pub fn integrate(module: &mut Module) {
     module
         .add_function("integration_function_typehints", |_| phper::ok(()))
         .argument(
-            Argument::by_val("s")
+            Argument::new("s")
                 .with_type_hint(ArgumentTypeHint::String)
                 .with_default_value("'foobarbaz'"),
         )
         .argument(
-            Argument::by_val("i")
+            Argument::new("i")
                 .with_type_hint(ArgumentTypeHint::Int)
                 .with_default_value("42"),
         )
         .argument(
-            Argument::by_val("f")
+            Argument::new("f")
                 .with_type_hint(ArgumentTypeHint::Float)
                 .with_default_value("7.89"),
         )
         .argument(
-            Argument::by_val("b")
+            Argument::new("b")
                 .with_type_hint(ArgumentTypeHint::Bool)
                 .with_default_value("true"),
         )
         .argument(
-            Argument::by_val("a")
+            Argument::new("a")
                 .with_type_hint(ArgumentTypeHint::Array)
                 .with_default_value("['a'=>'b']"),
         )
         .argument(
-            Argument::by_val("m")
+            Argument::new("m")
                 .with_type_hint(ArgumentTypeHint::Mixed)
                 .with_default_value("1.23"),
         )
-        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
 }
 
 fn make_i_foo_interface() -> InterfaceEntity {
     let mut interface = InterfaceEntity::new(r"IntegrationTest\TypeHints\IFoo");
     interface
         .add_method("getValue")
-        .return_type(ReturnType::by_val(ReturnTypeHint::String));
+        .return_type(ReturnType::new(ReturnTypeHint::String));
     interface
         .add_method("setValue")
-        .argument(Argument::by_val("value"));
+        .argument(Argument::new("value"));
 
     interface
 }
@@ -81,10 +81,10 @@ fn make_foo_handler() -> ClassEntity<()> {
             phper::ok(arguments[0].clone())
         })
         .argument(
-            Argument::by_val("foo")
+            Argument::new("foo")
                 .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))),
         )
-        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(
             String::from(I_FOO),
         )));
 
@@ -107,7 +107,7 @@ fn make_foo_class(i_foo: Interface) -> ClassEntity<()> {
                 .to_owned();
             Ok::<_, phper::Error>(value)
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::String));
+        .return_type(ReturnType::new(ReturnTypeHint::String));
 
     class
         .add_method("setValue", Visibility::Public, |this, arguments| {
@@ -115,7 +115,7 @@ fn make_foo_class(i_foo: Interface) -> ClassEntity<()> {
             this.set_property("value", ZVal::from(name));
             Ok::<_, phper::Error>(())
         })
-        .argument(Argument::by_val("foo"));
+        .argument(Argument::new("foo"));
 
     class.add_property("value", Visibility::Private, "");
 
@@ -142,7 +142,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
             phper::ok(())
         })
-        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String));
+        .argument(Argument::new("string_value").with_type_hint(ArgumentTypeHint::String));
 
     class
         .add_method(
@@ -154,7 +154,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("string_value")
+            Argument::new("string_value")
                 .with_type_hint(ArgumentTypeHint::String)
                 .optional(),
         );
@@ -169,7 +169,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("string_value")
+            Argument::new("string_value")
                 .with_type_hint(ArgumentTypeHint::String)
                 .allow_null(),
         );
@@ -180,7 +180,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             let _ = arguments[0].as_bool();
             phper::ok(())
         })
-        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool));
+        .argument(Argument::new("bool_value").with_type_hint(ArgumentTypeHint::Bool));
 
     class
         .add_method(
@@ -192,7 +192,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("bool_value")
+            Argument::new("bool_value")
                 .with_type_hint(ArgumentTypeHint::Bool)
                 .allow_null(),
         );
@@ -207,7 +207,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("bool_value")
+            Argument::new("bool_value")
                 .with_type_hint(ArgumentTypeHint::Bool)
                 .optional(),
         );
@@ -218,7 +218,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             let _ = arguments[0].expect_long()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int));
+        .argument(Argument::new("int_value").with_type_hint(ArgumentTypeHint::Int));
 
     class
         .add_method(
@@ -230,7 +230,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("int_value")
+            Argument::new("int_value")
                 .with_type_hint(ArgumentTypeHint::Int)
                 .allow_null(),
         );
@@ -245,7 +245,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("int_value")
+            Argument::new("int_value")
                 .with_type_hint(ArgumentTypeHint::Int)
                 .optional(),
         );
@@ -256,7 +256,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             let _ = arguments[0].expect_double()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float));
+        .argument(Argument::new("float_value").with_type_hint(ArgumentTypeHint::Float));
 
     class
         .add_method(
@@ -268,7 +268,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("float_value")
+            Argument::new("float_value")
                 .with_type_hint(ArgumentTypeHint::Float)
                 .optional(),
         );
@@ -283,7 +283,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("float_value")
+            Argument::new("float_value")
                 .with_type_hint(ArgumentTypeHint::Float)
                 .allow_null(),
         );
@@ -294,7 +294,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             let _ = arguments[0].expect_z_arr()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array));
+        .argument(Argument::new("array_value").with_type_hint(ArgumentTypeHint::Array));
 
     class
         .add_method(
@@ -306,7 +306,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("array_value")
+            Argument::new("array_value")
                 .with_type_hint(ArgumentTypeHint::Array)
                 .optional(),
         );
@@ -321,7 +321,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             },
         )
         .argument(
-            Argument::by_val("array_value")
+            Argument::new("array_value")
                 .with_type_hint(ArgumentTypeHint::Array)
                 .allow_null(),
         );
@@ -329,7 +329,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
     // Mixed tests
     class
         .add_method("testMixed", Visibility::Public, move |_, _| phper::ok(()))
-        .argument(Argument::by_val("mixed_value").with_type_hint(ArgumentTypeHint::Mixed));
+        .argument(Argument::new("mixed_value").with_type_hint(ArgumentTypeHint::Mixed));
 
     // Callable tests
     class
@@ -338,14 +338,14 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             Visibility::Public,
             move |_, _| phper::ok(()),
         )
-        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable));
+        .argument(Argument::new("callable_value").with_type_hint(ArgumentTypeHint::Callable));
 
     class
         .add_method("testCallableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("callable_value")
+            Argument::new("callable_value")
                 .with_type_hint(ArgumentTypeHint::Callable)
                 .allow_null(),
         );
@@ -355,21 +355,21 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("callable_value")
+            Argument::new("callable_value")
                 .with_type_hint(ArgumentTypeHint::Callable)
                 .optional(),
         );
 
     class
         .add_method("testObject", Visibility::Public, move |_, _| phper::ok(()))
-        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object));
+        .argument(Argument::new("object_value").with_type_hint(ArgumentTypeHint::Object));
 
     class
         .add_method("testObjectNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("object_value")
+            Argument::new("object_value")
                 .with_type_hint(ArgumentTypeHint::Object)
                 .allow_null(),
         );
@@ -379,7 +379,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("object_value")
+            Argument::new("object_value")
                 .with_type_hint(ArgumentTypeHint::Object)
                 .optional(),
         );
@@ -390,14 +390,14 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             Visibility::Public,
             move |_, _| phper::ok(()),
         )
-        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable));
+        .argument(Argument::new("iterable_value").with_type_hint(ArgumentTypeHint::Iterable));
 
     class
         .add_method("testIterableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("iterable_value")
+            Argument::new("iterable_value")
                 .with_type_hint(ArgumentTypeHint::Iterable)
                 .allow_null(),
         );
@@ -407,21 +407,21 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("iterable_value")
+            Argument::new("iterable_value")
                 .with_type_hint(ArgumentTypeHint::Iterable)
                 .optional(),
         );
 
     class
         .add_method("testNull", Visibility::Public, move |_, _| phper::ok(()))
-        .argument(Argument::by_val("null_value").with_type_hint(ArgumentTypeHint::Null));
+        .argument(Argument::new("null_value").with_type_hint(ArgumentTypeHint::Null));
 
     class
         .add_method("testClassEntry", Visibility::Public, move |_, _| {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("classentry")
+            Argument::new("classentry")
                 .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))),
         );
 
@@ -430,7 +430,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("classentry")
+            Argument::new("classentry")
                 .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO)))
                 .allow_null(),
         );
@@ -440,7 +440,7 @@ fn make_arg_typehint_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("classentry")
+            Argument::new("classentry")
                 .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO)))
                 .optional(),
         );
@@ -452,7 +452,7 @@ fn make_return_typehint_class() -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ReturnTypeHintTest");
     class
         .add_method("returnNull", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Null));
+        .return_type(ReturnType::new(ReturnTypeHint::Null));
 
     class
         .add_method(
@@ -460,53 +460,53 @@ fn make_return_typehint_class() -> ClassEntity<()> {
             Visibility::Public,
             move |_, _| phper::ok(()),
         )
-        .return_type(ReturnType::by_val(ReturnTypeHint::String));
+        .return_type(ReturnType::new(ReturnTypeHint::String));
 
     class
         .add_method("returnStringNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::String).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::String).allow_null());
 
     class
         .add_method("returnBool", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Bool));
+        .return_type(ReturnType::new(ReturnTypeHint::Bool));
 
     class
         .add_method("returnBoolNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Bool).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::Bool).allow_null());
 
     class
         .add_method("returnInt", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Int));
+        .return_type(ReturnType::new(ReturnTypeHint::Int));
 
     class
         .add_method("returnIntNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Int).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::Int).allow_null());
 
     class
         .add_method("returnFloat", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Float));
+        .return_type(ReturnType::new(ReturnTypeHint::Float));
 
     class
         .add_method("returnFloatNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Float).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::Float).allow_null());
 
     class
         .add_method("returnArray", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Array));
+        .return_type(ReturnType::new(ReturnTypeHint::Array));
 
     class
         .add_method("returnArrayNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Array).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::Array).allow_null());
 
     class
         .add_method(
@@ -514,47 +514,47 @@ fn make_return_typehint_class() -> ClassEntity<()> {
             Visibility::Public,
             move |_, _| phper::ok(()),
         )
-        .return_type(ReturnType::by_val(ReturnTypeHint::Object));
+        .return_type(ReturnType::new(ReturnTypeHint::Object));
 
     class
         .add_method("returnObjectNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Object).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::Object).allow_null());
 
     class
         .add_method("returnCallable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Callable));
+        .return_type(ReturnType::new(ReturnTypeHint::Callable));
 
     class
         .add_method("returnCallableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Callable).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::Callable).allow_null());
 
     class
         .add_method("returnIterable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Iterable));
+        .return_type(ReturnType::new(ReturnTypeHint::Iterable));
 
     class
         .add_method("returnIterableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::Iterable).allow_null());
+        .return_type(ReturnType::new(ReturnTypeHint::Iterable).allow_null());
 
     class
         .add_method("returnMixed", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
+        .return_type(ReturnType::new(ReturnTypeHint::Mixed));
 
     class
         .add_method("returnClassEntry", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(
             String::from(I_FOO),
         )));
 
@@ -565,16 +565,16 @@ fn make_return_typehint_class() -> ClassEntity<()> {
             move |_, _| phper::ok(()),
         )
         .return_type(
-            ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))).allow_null(),
+            ReturnType::new(ReturnTypeHint::ClassEntry(String::from(I_FOO))).allow_null(),
         );
 
     class
         .add_method("returnNever", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Never));
+        .return_type(ReturnType::new(ReturnTypeHint::Never));
 
     class
         .add_method("returnVoid", Visibility::Public, move |_, _| phper::ok(()))
-        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
 
     class
 }
@@ -587,7 +587,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("string_value")
+            Argument::new("string_value")
                 .with_type_hint(ArgumentTypeHint::String)
                 .with_default_value("'foobarbaz'"),
         ); //NB single quotes!
@@ -597,7 +597,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("const_value")
+            Argument::new("const_value")
                 .with_type_hint(ArgumentTypeHint::String)
                 .with_default_value("PHP_VERSION"),
         );
@@ -607,7 +607,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("bool_value")
+            Argument::new("bool_value")
                 .with_type_hint(ArgumentTypeHint::Bool)
                 .with_default_value("true"),
         );
@@ -617,7 +617,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("bool_value")
+            Argument::new("bool_value")
                 .with_type_hint(ArgumentTypeHint::Bool)
                 .with_default_value("false"),
         );
@@ -625,7 +625,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
     class
         .add_method("intDefault", Visibility::Public, move |_, _| phper::ok(()))
         .argument(
-            Argument::by_val("int_value")
+            Argument::new("int_value")
                 .with_type_hint(ArgumentTypeHint::Int)
                 .with_default_value("42"),
         );
@@ -637,7 +637,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             move |_, _| phper::ok(()),
         )
         .argument(
-            Argument::by_val("float_value")
+            Argument::new("float_value")
                 .with_type_hint(ArgumentTypeHint::Float)
                 .with_default_value("3.14159"),
         );
@@ -649,7 +649,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             move |_, _| phper::ok(()),
         )
         .argument(
-            Argument::by_val("array_value")
+            Argument::new("array_value")
                 .with_type_hint(ArgumentTypeHint::Array)
                 .with_default_value("['a' => 'b']"),
         );
@@ -659,7 +659,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             phper::ok(())
         })
         .argument(
-            Argument::by_val("iterable_value")
+            Argument::new("iterable_value")
                 .with_type_hint(ArgumentTypeHint::Iterable)
                 .with_default_value("[0 => 1]"),
         );
@@ -671,7 +671,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
             move |_, _| phper::ok(()),
         )
         .argument(
-            Argument::by_val("mixed_value")
+            Argument::new("mixed_value")
                 .with_type_hint(ArgumentTypeHint::Mixed)
                 .with_default_value("999"),
         );

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -17,16 +17,30 @@ use phper::{
     types::{ArgumentTypeHint, ReturnTypeHint},
     values::ZVal,
 };
+use std::ffi::CString;
 
 const I_FOO: &str = r"IntegrationTest\TypeHints\IFoo";
 
 pub fn integrate(module: &mut Module) {
     let i_foo = module.add_interface(make_i_foo_interface());
     let foo_class = module.add_class(make_foo_class(i_foo.clone()));
-    let _ = module.add_class(make_b_class(foo_class.clone(), i_foo.clone()));
-    let _ = module.add_class(make_foo_handler());
-    let _ = module.add_class(make_arg_typehint_class());
-    let _ = module.add_class(make_return_typehint_class());
+    module.add_class(make_b_class(foo_class.clone(), i_foo.clone()));
+    module.add_class(make_foo_handler());
+    module.add_class(make_arg_typehint_class());
+    module.add_class(make_return_typehint_class());
+    module.add_class(make_arg_default_value_class());
+    module.add_function("integration_function_typehints", |_| {
+            phper::ok(())
+            },
+        )
+        .argument(Argument::by_val("s").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("'foobarbaz'").unwrap()))
+        .argument(Argument::by_val("i").with_type_hint(ArgumentTypeHint::Int).with_default_value(CString::new("42").unwrap()))
+        .argument(Argument::by_val("f").with_type_hint(ArgumentTypeHint::Float).with_default_value(CString::new("7.89").unwrap()))
+        .argument(Argument::by_val("b").with_type_hint(ArgumentTypeHint::Bool).with_default_value(CString::new("true").unwrap()))
+        .argument(Argument::by_val("a").with_type_hint(ArgumentTypeHint::Array).with_default_value(CString::new("['a'=>'b']").unwrap()))
+        .argument(Argument::by_val("m").with_type_hint(ArgumentTypeHint::Mixed).with_default_value(CString::new("1.23").unwrap()))
+        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+
 }
 
 fn make_i_foo_interface() -> InterfaceEntity {
@@ -123,7 +137,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
             let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
             phper::ok(())
         })
-        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).nullable());
+        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).allow_null());
 
     // Bool tests
     class
@@ -138,7 +152,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
             let _ = arguments[0].as_bool();
             phper::ok(())
         })
-        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).nullable());
+        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).allow_null());
 
     class
         .add_method("testBoolOptional", Visibility::Public, move |_, arguments| {
@@ -160,7 +174,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
             let _ = arguments[0].expect_long()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).nullable());
+        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).allow_null());
 
     class
         .add_method("testIntOptional", Visibility::Public, move |_, arguments| {
@@ -189,7 +203,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
             let _ = arguments[0].expect_double()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).nullable());
+        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).allow_null());
 
     // Array tests
     class
@@ -211,7 +225,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
             let _ = arguments[0].expect_z_arr()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).nullable());
+        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).allow_null());
 
     // Mixed tests
     class
@@ -231,7 +245,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .add_method("testCallableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable).nullable());
+        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable).allow_null());
 
     class
         .add_method("testCallableOptional", Visibility::Public, move |_, _| {
@@ -249,7 +263,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .add_method("testObjectNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object).nullable());
+        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object).allow_null());
 
     class
         .add_method("testObjectOptional", Visibility::Public, move |_, _| {
@@ -267,7 +281,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .add_method("testIterableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).nullable());
+        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).allow_null());
 
     class
         .add_method("testIterableOptional", Visibility::Public, move |_, _| {
@@ -291,7 +305,7 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .add_method("testClassEntryNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))).nullable());
+        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))).allow_null());
 
     class
         .add_method("testClassEntryOptional", Visibility::Public, move |_, _| {
@@ -435,6 +449,66 @@ fn make_return_typehint_class() ->ClassEntity<()> {
             phper::ok(())
         })
         .return_type(ReturnType::by_val(ReturnTypeHint::Void));
+
+    class
+}
+
+fn make_arg_default_value_class() ->ClassEntity<()> {
+    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ArgumentDefaultValueTest");
+
+    class
+        .add_method("stringDefault", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("'foobarbaz'").unwrap())); //NB single quotes!
+
+    class
+        .add_method("stringConstantDefault", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("const_value").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("PHP_VERSION").unwrap()));
+
+    class
+        .add_method("boolDefaultTrue", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).with_default_value(CString::new("true").unwrap()));
+
+    class
+        .add_method("boolDefaultFalse", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).with_default_value(CString::new("false").unwrap()));
+
+    class
+        .add_method("intDefault", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).with_default_value(CString::new("42").unwrap()));
+
+    class
+        .add_method("floatDefault", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).with_default_value(CString::new("3.14159").unwrap()));
+
+    class
+        .add_method("arrayDefault", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).with_default_value(CString::new("['a' => 'b']").unwrap()));
+
+    class
+        .add_method("iterableDefault", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).with_default_value(CString::new("[0 => 1]").unwrap()));
+
+    class
+        .add_method("mixedDefault", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("mixed_value").with_type_hint(ArgumentTypeHint::Mixed).with_default_value(CString::new("999").unwrap()));
 
     class
 }

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -14,21 +14,24 @@ use phper::{
     },
     functions::{Argument, ReturnType},
     modules::Module,
-    types::{TypeHint, TypeInfo},
+    types::{ArgumentTypeHint, ReturnTypeHint, TypeInfo},
     values::ZVal,
 };
+
+const I_FOO: &str = r"IntegrationTest\TypeHints\IFoo";
 
 pub fn integrate(module: &mut Module) {
     let i_foo = module.add_interface(make_i_foo_interface());
     let a_class = module.add_class(make_foo_class(i_foo.clone()));
     let _b_class = module.add_class(make_b_class(a_class.clone(), i_foo.clone()));
-    let _c_class = module.add_class(make_c_class(i_foo.clone()));
+    let _ = module.add_class(make_arg_typehint_class());
+    let _ = module.add_class(make_return_typehint_class());
 }
 
 fn make_i_foo_interface() -> InterfaceEntity {
     let mut interface = InterfaceEntity::new(r"IntegrationTest\TypeHints\IFoo");
     interface.add_method("getValue")
-        .return_type(ReturnType::by_val(TypeInfo::STRING));
+        .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
     interface.add_method("setValue")
         .argument(Argument::by_val("foo"));
 
@@ -54,7 +57,7 @@ fn make_foo_class(
                 .to_owned();
             Ok::<_, phper::Error>(value)
         })
-        .return_type(ReturnType::by_val(TypeInfo::STRING));
+        .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
 
     class
         .add_method("setValue", Visibility::Public, |this, arguments| {
@@ -85,31 +88,29 @@ fn make_b_class(
     class
 }
 
-fn make_c_class(
-    _i_foo: Interface,
-) ->ClassEntity<()> {
-    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\C");
+fn make_arg_typehint_class() ->ClassEntity<()> {
+    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ArgumentTypeHintTest");
     // String tests
     class
         .add_method("testString", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
             phper::ok(())
         })
-        .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String));
+        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String));
 
     class
         .add_method("testStringOptional", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
             phper::ok(())
         })
-        .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String).optional());
+        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).optional());
 
     class
         .add_method("testStringNullable", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
             phper::ok(())
         })
-        .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String).nullable());
+        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).nullable());
 
     // Bool tests
     class
@@ -117,21 +118,21 @@ fn make_c_class(
             let _ = arguments[0].as_bool();
             phper::ok(())
         })
-        .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool));
+        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool));
 
     class
         .add_method("testBoolNullable", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].as_bool();
             phper::ok(())
         })
-        .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool).nullable());
+        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).nullable());
 
     class
         .add_method("testBoolOptional", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_bool()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool).optional());
+        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).optional());
 
     // Int tests
     class
@@ -139,21 +140,21 @@ fn make_c_class(
             let _ = arguments[0].expect_long()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("int_value").with_type_hint(TypeHint::Int));
+        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int));
 
     class
         .add_method("testIntNullable", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_long()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("int_value").with_type_hint(TypeHint::Int).nullable());
+        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).nullable());
 
     class
         .add_method("testIntOptional", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_long()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("int_value").with_type_hint(TypeHint::Int).optional());
+        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).optional());
 
     // Float tests
     class
@@ -161,21 +162,21 @@ fn make_c_class(
             let _ = arguments[0].expect_double()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("float_value").with_type_hint(TypeHint::Float));
+        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float));
 
     class
         .add_method("testFloatOptional", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_double()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("float_value").with_type_hint(TypeHint::Float).optional());
+        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).optional());
 
     class
         .add_method("testFloatNullable", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_double()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("float_value").with_type_hint(TypeHint::Float).nullable());
+        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).nullable());
 
     // Array tests
     class
@@ -183,109 +184,119 @@ fn make_c_class(
             let _ = arguments[0].expect_z_arr()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("array_value").with_type_hint(TypeHint::Array));
+        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array));
 
     class
         .add_method("testArrayOptional", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_z_arr()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("array_value").with_type_hint(TypeHint::Array).optional());
+        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).optional());
 
     class
         .add_method("testArrayNullable", Visibility::Public, move |_, arguments| {
             let _ = arguments[0].expect_z_arr()?;
             phper::ok(())
         })
-        .argument(Argument::by_val("array_value").with_type_hint(TypeHint::Array).nullable());
+        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).nullable());
 
     // Mixed tests
     class
         .add_method("testMixed", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("mixed_value").with_type_hint(TypeHint::Mixed));
+        .argument(Argument::by_val("mixed_value").with_type_hint(ArgumentTypeHint::Mixed));
 
     // Callable tests
     class
         .add_method("testCallable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("callable_value").with_type_hint(TypeHint::Callable));
+        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable));
 
     class
         .add_method("testCallableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("callable_value").with_type_hint(TypeHint::Callable).nullable());
+        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable).nullable());
 
     class
         .add_method("testCallableOptional", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("callable_value").with_type_hint(TypeHint::Callable).optional());
+        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable).optional());
 
     class
         .add_method("testObject", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("object_value").with_type_hint(TypeHint::Object));
+        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object));
 
     class
         .add_method("testObjectNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("object_value").with_type_hint(TypeHint::Object).nullable());
+        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object).nullable());
 
     class
         .add_method("testObjectOptional", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("object_value").with_type_hint(TypeHint::Object).optional());
+        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object).optional());
 
     class
         .add_method("testIterable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("iterable_value").with_type_hint(TypeHint::Iterable));
+        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable));
 
     class
         .add_method("testIterableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("iterable_value").with_type_hint(TypeHint::Iterable).nullable());
+        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).nullable());
 
     class
         .add_method("testIterableOptional", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("iterable_value").with_type_hint(TypeHint::Iterable).optional());
+        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).optional());
 
     class
         .add_method("testNull", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("null_value").with_type_hint(TypeHint::Null));
+        .argument(Argument::by_val("null_value").with_type_hint(ArgumentTypeHint::Null));
 
-    // Class type test (assuming you have a classEntry for "DateTime")
     class
         .add_method("testClassEntry", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("classentry").with_type_hint(TypeHint::ClassEntry(String::from("todo"))));
+        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))));
 
-    /*class
-        .add_method("testClassNullable", Visibility::Public, move |_, arguments| {
-            if arguments[0].is_null() {
-                phper::ok("null")
-            } else {
-                let obj = arguments[0].expect_z_obj()?;
-                let class_name = obj.get_class_name()?;
-                phper::ok(class_name)
-            }
+    class
+        .add_method("testClassEntryNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
         })
-        .argument(Argument::by_val("datetime_obj").with_type_hint(TypeHint::ClassEntry(get_date_time_class_entry())).nullable());*/
+        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))).nullable());
 
+    class
+        .add_method("testClassEntryOptional", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))).optional());
+
+    class
+}
+
+fn make_return_typehint_class() ->ClassEntity<()> {
+    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ReturnTypeHintTest");
+    // String tests
+    class
+        .add_method("returnString", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
 
     class
 }

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -15,7 +15,6 @@ use phper::{
     types::{ArgumentTypeHint, ReturnTypeHint},
     values::ZVal,
 };
-use std::ffi::CString;
 
 const I_FOO: &str = r"IntegrationTest\TypeHints\IFoo";
 
@@ -32,32 +31,32 @@ pub fn integrate(module: &mut Module) {
         .argument(
             Argument::by_val("s")
                 .with_type_hint(ArgumentTypeHint::String)
-                .with_default_value(CString::new("'foobarbaz'").unwrap()),
+                .with_default_value("'foobarbaz'"),
         )
         .argument(
             Argument::by_val("i")
                 .with_type_hint(ArgumentTypeHint::Int)
-                .with_default_value(CString::new("42").unwrap()),
+                .with_default_value("42"),
         )
         .argument(
             Argument::by_val("f")
                 .with_type_hint(ArgumentTypeHint::Float)
-                .with_default_value(CString::new("7.89").unwrap()),
+                .with_default_value("7.89"),
         )
         .argument(
             Argument::by_val("b")
                 .with_type_hint(ArgumentTypeHint::Bool)
-                .with_default_value(CString::new("true").unwrap()),
+                .with_default_value("true"),
         )
         .argument(
             Argument::by_val("a")
                 .with_type_hint(ArgumentTypeHint::Array)
-                .with_default_value(CString::new("['a'=>'b']").unwrap()),
+                .with_default_value("['a'=>'b']"),
         )
         .argument(
             Argument::by_val("m")
                 .with_type_hint(ArgumentTypeHint::Mixed)
-                .with_default_value(CString::new("1.23").unwrap()),
+                .with_default_value("1.23"),
         )
         .return_type(ReturnType::by_val(ReturnTypeHint::Void));
 }
@@ -590,7 +589,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("string_value")
                 .with_type_hint(ArgumentTypeHint::String)
-                .with_default_value(CString::new("'foobarbaz'").unwrap()),
+                .with_default_value("'foobarbaz'"),
         ); //NB single quotes!
 
     class
@@ -600,7 +599,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("const_value")
                 .with_type_hint(ArgumentTypeHint::String)
-                .with_default_value(CString::new("PHP_VERSION").unwrap()),
+                .with_default_value("PHP_VERSION"),
         );
 
     class
@@ -610,7 +609,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("bool_value")
                 .with_type_hint(ArgumentTypeHint::Bool)
-                .with_default_value(CString::new("true").unwrap()),
+                .with_default_value("true"),
         );
 
     class
@@ -620,7 +619,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("bool_value")
                 .with_type_hint(ArgumentTypeHint::Bool)
-                .with_default_value(CString::new("false").unwrap()),
+                .with_default_value("false"),
         );
 
     class
@@ -628,7 +627,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("int_value")
                 .with_type_hint(ArgumentTypeHint::Int)
-                .with_default_value(CString::new("42").unwrap()),
+                .with_default_value("42"),
         );
 
     class
@@ -640,7 +639,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("float_value")
                 .with_type_hint(ArgumentTypeHint::Float)
-                .with_default_value(CString::new("3.14159").unwrap()),
+                .with_default_value("3.14159"),
         );
 
     class
@@ -652,7 +651,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("array_value")
                 .with_type_hint(ArgumentTypeHint::Array)
-                .with_default_value(CString::new("['a' => 'b']").unwrap()),
+                .with_default_value("['a' => 'b']"),
         );
 
     class
@@ -662,7 +661,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("iterable_value")
                 .with_type_hint(ArgumentTypeHint::Iterable)
-                .with_default_value(CString::new("[0 => 1]").unwrap()),
+                .with_default_value("[0 => 1]"),
         );
 
     class
@@ -674,7 +673,7 @@ fn make_arg_default_value_class() -> ClassEntity<()> {
         .argument(
             Argument::by_val("mixed_value")
                 .with_type_hint(ArgumentTypeHint::Mixed)
-                .with_default_value(CString::new("999").unwrap()),
+                .with_default_value("999"),
         );
 
     class

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -81,12 +81,11 @@ fn make_foo_handler() -> ClassEntity<()> {
             phper::ok(arguments[0].clone())
         })
         .argument(
-            Argument::new("foo")
-                .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))),
+            Argument::new("foo").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))),
         )
-        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(
-            String::from(I_FOO),
-        )));
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(String::from(
+            I_FOO,
+        ))));
 
     class
 }
@@ -554,9 +553,9 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .add_method("returnClassEntry", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(
-            String::from(I_FOO),
-        )));
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(String::from(
+            I_FOO,
+        ))));
 
     class
         .add_method(
@@ -564,9 +563,7 @@ fn make_return_typehint_class() -> ClassEntity<()> {
             Visibility::Public,
             move |_, _| phper::ok(()),
         )
-        .return_type(
-            ReturnType::new(ReturnTypeHint::ClassEntry(String::from(I_FOO))).allow_null(),
-        );
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(String::from(I_FOO))).allow_null());
 
     class
         .add_method("returnNever", Visibility::Public, move |_, _| phper::ok(()))

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -14,7 +14,7 @@ use phper::{
     },
     functions::{Argument, ReturnType},
     modules::Module,
-    types::{ArgumentTypeHint, ReturnTypeHint, TypeInfo},
+    types::{ArgumentTypeHint, ReturnTypeHint},
     values::ZVal,
 };
 
@@ -22,8 +22,9 @@ const I_FOO: &str = r"IntegrationTest\TypeHints\IFoo";
 
 pub fn integrate(module: &mut Module) {
     let i_foo = module.add_interface(make_i_foo_interface());
-    let a_class = module.add_class(make_foo_class(i_foo.clone()));
-    let _b_class = module.add_class(make_b_class(a_class.clone(), i_foo.clone()));
+    let foo_class = module.add_class(make_foo_class(i_foo.clone()));
+    let _ = module.add_class(make_b_class(foo_class.clone(), i_foo.clone()));
+    let _ = module.add_class(make_foo_handler());
     let _ = module.add_class(make_arg_typehint_class());
     let _ = module.add_class(make_return_typehint_class());
 }
@@ -31,11 +32,23 @@ pub fn integrate(module: &mut Module) {
 fn make_i_foo_interface() -> InterfaceEntity {
     let mut interface = InterfaceEntity::new(r"IntegrationTest\TypeHints\IFoo");
     interface.add_method("getValue")
-        .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
+        .return_type(ReturnType::by_val(ReturnTypeHint::String));
     interface.add_method("setValue")
-        .argument(Argument::by_val("foo"));
+        .argument(Argument::by_val("value"));
 
     interface
+}
+
+fn make_foo_handler() -> ClassEntity<()> {
+    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\FooHandler");
+
+    class.add_method("handle", Visibility::Public, |_,arguments| {
+        phper::ok(arguments[0].clone())
+    })
+        .argument(Argument::by_val("foo").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))))
+        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))));
+
+    class
 }
 
 fn make_foo_class(
@@ -57,7 +70,7 @@ fn make_foo_class(
                 .to_owned();
             Ok::<_, phper::Error>(value)
         })
-        .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
+        .return_type(ReturnType::by_val(ReturnTypeHint::String));
 
     class
         .add_method("setValue", Visibility::Public, |this, arguments| {
@@ -291,12 +304,137 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
 
 fn make_return_typehint_class() ->ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ReturnTypeHintTest");
-    // String tests
+    class
+        .add_method("returnNull", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Null));
+
     class
         .add_method("returnString", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(TypeInfo::STRING).with_type_hint(ReturnTypeHint::String));
+        .return_type(ReturnType::by_val(ReturnTypeHint::String));
+
+    class
+        .add_method("returnStringNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::String).allow_null());
+
+    class
+        .add_method("returnBool", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Bool));
+
+    class
+        .add_method("returnBoolNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Bool).allow_null());
+
+    class
+        .add_method("returnInt", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Int));
+
+    class
+        .add_method("returnIntNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Int).allow_null());
+
+    class
+        .add_method("returnFloat", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Float));
+
+    class
+        .add_method("returnFloatNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Float).allow_null());
+
+    class
+        .add_method("returnArray", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Array));
+
+    class
+        .add_method("returnArrayNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Array).allow_null());
+
+    class
+        .add_method("returnObject", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Object));
+
+    class
+        .add_method("returnObjectNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Object).allow_null());
+
+    class
+        .add_method("returnCallable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Callable));
+
+    class
+        .add_method("returnCallableNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Callable).allow_null());
+
+    class
+        .add_method("returnIterable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Iterable));
+
+    class
+        .add_method("returnIterableNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Iterable).allow_null());
+
+    class
+        .add_method("returnMixed", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
+
+    class
+        .add_method("returnClassEntry", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))));
+
+    class
+        .add_method("returnClassEntryNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))).allow_null());
+
+    class
+        .add_method("returnNever", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Never));
+
+    class
+        .add_method("returnVoid", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .return_type(ReturnType::by_val(ReturnTypeHint::Void));
 
     class
 }

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -10,7 +10,7 @@
 
 use phper::{
     classes::{
-        ClassEntity, ClassEntry, Interface, InterfaceEntity, StateClass, Visibility,
+        ClassEntity, Interface, InterfaceEntity, StateClass, Visibility,
     },
     functions::{Argument, ReturnType},
     modules::Module,
@@ -22,7 +22,7 @@ pub fn integrate(module: &mut Module) {
     let i_foo = module.add_interface(make_i_foo_interface());
     let a_class = module.add_class(make_foo_class(i_foo.clone()));
     let _b_class = module.add_class(make_b_class(a_class.clone(), i_foo.clone()));
-    let _c_class = module.add_class(make_c_class());
+    let _c_class = module.add_class(make_c_class(i_foo.clone()));
 }
 
 fn make_i_foo_interface() -> InterfaceEntity {
@@ -80,40 +80,211 @@ fn make_b_class(
         .add_static_method("createFoo", Visibility::Public, move |_| {
             let object = a_class.init_object()?;
             Ok::<_, phper::Error>(object)
-        }); //todo return ClassEntity(i_foo)
+        });
 
     class
 }
 
-fn make_c_class() ->ClassEntity<()> {
+fn make_c_class(
+    _i_foo: Interface,
+) ->ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\C");
+    // String tests
     class
-        .add_method("exString", Visibility::Public, move |_, arguments| {
-            let name = arguments[0].expect_z_str()?.to_str()?.to_string();
-            phper::ok(name)
+        .add_method("testString", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
+            phper::ok(())
         })
         .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String));
 
     class
-        .add_method("exStringOptional", Visibility::Public, move |_, arguments| {
-            let name = arguments[0].expect_z_str()?.to_str()?.to_string();
-            phper::ok(name)
+        .add_method("testStringOptional", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
+            phper::ok(())
+        })
+        .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String).optional());
+
+    class
+        .add_method("testStringNullable", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
+            phper::ok(())
         })
         .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String).nullable());
 
+    // Bool tests
     class
-        .add_method("exBool", Visibility::Public, move |_, arguments| {
-            let name = arguments[0].as_bool();
-            phper::ok(name)
+        .add_method("testBool", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].as_bool();
+            phper::ok(())
         })
         .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool));
 
     class
-        .add_method("exBoolOptional", Visibility::Public, move |_, arguments| {
-            let name = arguments[0].as_bool();
-            phper::ok(name)
+        .add_method("testBoolNullable", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].as_bool();
+            phper::ok(())
         })
         .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool).nullable());
+
+    class
+        .add_method("testBoolOptional", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_bool()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool).optional());
+
+    // Int tests
+    class
+        .add_method("testInt", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_long()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("int_value").with_type_hint(TypeHint::Int));
+
+    class
+        .add_method("testIntNullable", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_long()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("int_value").with_type_hint(TypeHint::Int).nullable());
+
+    class
+        .add_method("testIntOptional", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_long()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("int_value").with_type_hint(TypeHint::Int).optional());
+
+    // Float tests
+    class
+        .add_method("testFloat", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_double()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("float_value").with_type_hint(TypeHint::Float));
+
+    class
+        .add_method("testFloatOptional", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_double()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("float_value").with_type_hint(TypeHint::Float).optional());
+
+    class
+        .add_method("testFloatNullable", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_double()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("float_value").with_type_hint(TypeHint::Float).nullable());
+
+    // Array tests
+    class
+        .add_method("testArray", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_z_arr()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("array_value").with_type_hint(TypeHint::Array));
+
+    class
+        .add_method("testArrayOptional", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_z_arr()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("array_value").with_type_hint(TypeHint::Array).optional());
+
+    class
+        .add_method("testArrayNullable", Visibility::Public, move |_, arguments| {
+            let _ = arguments[0].expect_z_arr()?;
+            phper::ok(())
+        })
+        .argument(Argument::by_val("array_value").with_type_hint(TypeHint::Array).nullable());
+
+    // Mixed tests
+    class
+        .add_method("testMixed", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("mixed_value").with_type_hint(TypeHint::Mixed));
+
+    // Callable tests
+    class
+        .add_method("testCallable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("callable_value").with_type_hint(TypeHint::Callable));
+
+    class
+        .add_method("testCallableNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("callable_value").with_type_hint(TypeHint::Callable).nullable());
+
+    class
+        .add_method("testCallableOptional", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("callable_value").with_type_hint(TypeHint::Callable).optional());
+
+    class
+        .add_method("testObject", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("object_value").with_type_hint(TypeHint::Object));
+
+    class
+        .add_method("testObjectNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("object_value").with_type_hint(TypeHint::Object).nullable());
+
+    class
+        .add_method("testObjectOptional", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("object_value").with_type_hint(TypeHint::Object).optional());
+
+    class
+        .add_method("testIterable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("iterable_value").with_type_hint(TypeHint::Iterable));
+
+    class
+        .add_method("testIterableNullable", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("iterable_value").with_type_hint(TypeHint::Iterable).nullable());
+
+    class
+        .add_method("testIterableOptional", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("iterable_value").with_type_hint(TypeHint::Iterable).optional());
+
+    class
+        .add_method("testNull", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("null_value").with_type_hint(TypeHint::Null));
+
+    // Class type test (assuming you have a classEntry for "DateTime")
+    class
+        .add_method("testClassEntry", Visibility::Public, move |_, _| {
+            phper::ok(())
+        })
+        .argument(Argument::by_val("classentry").with_type_hint(TypeHint::ClassEntry(String::from("todo"))));
+
+    /*class
+        .add_method("testClassNullable", Visibility::Public, move |_, arguments| {
+            if arguments[0].is_null() {
+                phper::ok("null")
+            } else {
+                let obj = arguments[0].expect_z_obj()?;
+                let class_name = obj.get_class_name()?;
+                phper::ok(class_name)
+            }
+        })
+        .argument(Argument::by_val("datetime_obj").with_type_hint(TypeHint::ClassEntry(get_date_time_class_entry())).nullable());*/
 
 
     class

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2022 PHPER Framework Team
+// PHPER is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan
+// PSL v2. You may obtain a copy of Mulan PSL v2 at:
+//          http://license.coscl.org.cn/MulanPSL2
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
+use phper::{
+    classes::{
+        ClassEntity, ClassEntry, Interface, InterfaceEntity, StateClass, Visibility,
+    },
+    functions::{Argument, ReturnType},
+    modules::Module,
+    types::{TypeHint, TypeInfo},
+    values::ZVal,
+};
+
+pub fn integrate(module: &mut Module) {
+    let i_foo = module.add_interface(make_i_foo_interface());
+    let a_class = module.add_class(make_foo_class(i_foo.clone()));
+    let _b_class = module.add_class(make_b_class(a_class.clone(), i_foo.clone()));
+    let _c_class = module.add_class(make_c_class());
+}
+
+fn make_i_foo_interface() -> InterfaceEntity {
+    let mut interface = InterfaceEntity::new(r"IntegrationTest\TypeHints\IFoo");
+    interface.add_method("getValue")
+        .return_type(ReturnType::by_val(TypeInfo::STRING));
+    interface.add_method("setValue")
+        .argument(Argument::by_val("foo"));
+
+    interface
+}
+
+fn make_foo_class(
+    i_foo: Interface,
+) -> ClassEntity<()> {
+    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\Foo");
+
+    //leak Interface so that ClassEntry can be retrieved later, during module startup
+    let i_foo_copy: &'static Interface = Box::leak(Box::new(i_foo));
+    class.implements(move || {
+        i_foo_copy.as_class_entry()
+    });
+    class
+        .add_method("getValue", Visibility::Public, |this,_| {
+            let value = this
+                .get_property("value")
+                .expect_z_str()?
+                .to_str()?
+                .to_owned();
+            Ok::<_, phper::Error>(value)
+        })
+        .return_type(ReturnType::by_val(TypeInfo::STRING));
+
+    class
+        .add_method("setValue", Visibility::Public, |this, arguments| {
+            let name = arguments[0].expect_z_str()?.to_str()?;
+            this.set_property("value", ZVal::from(name));
+            Ok::<_, phper::Error>(())
+        })
+        .argument(Argument::by_val("foo"));
+
+    class.add_property("value", Visibility::Private, "");
+
+    class
+}
+
+fn make_b_class(
+    a_class: StateClass<()>,
+    i_foo: Interface,
+) -> ClassEntity<()> {
+    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\B");
+    let _i_foo_copy: &'static Interface = Box::leak(Box::new(i_foo));
+
+    class
+        .add_static_method("createFoo", Visibility::Public, move |_| {
+            let object = a_class.init_object()?;
+            Ok::<_, phper::Error>(object)
+        }); //todo return ClassEntity(i_foo)
+
+    class
+}
+
+fn make_c_class() ->ClassEntity<()> {
+    let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\C");
+    class
+        .add_method("exString", Visibility::Public, move |_, arguments| {
+            let name = arguments[0].expect_z_str()?.to_str()?.to_string();
+            phper::ok(name)
+        })
+        .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String));
+
+    class
+        .add_method("exStringOptional", Visibility::Public, move |_, arguments| {
+            let name = arguments[0].expect_z_str()?.to_str()?.to_string();
+            phper::ok(name)
+        })
+        .argument(Argument::by_val("string_value").with_type_hint(TypeHint::String).nullable());
+
+    class
+        .add_method("exBool", Visibility::Public, move |_, arguments| {
+            let name = arguments[0].as_bool();
+            phper::ok(name)
+        })
+        .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool));
+
+    class
+        .add_method("exBoolOptional", Visibility::Public, move |_, arguments| {
+            let name = arguments[0].as_bool();
+            phper::ok(name)
+        })
+        .argument(Argument::by_val("bool_value").with_type_hint(TypeHint::Bool).nullable());
+
+
+    class
+}

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -9,9 +9,7 @@
 // See the Mulan PSL v2 for more details.
 
 use phper::{
-    classes::{
-        ClassEntity, Interface, InterfaceEntity, StateClass, Visibility,
-    },
+    classes::{ClassEntity, Interface, InterfaceEntity, StateClass, Visibility},
     functions::{Argument, ReturnType},
     modules::Module,
     types::{ArgumentTypeHint, ReturnTypeHint},
@@ -29,25 +27,48 @@ pub fn integrate(module: &mut Module) {
     module.add_class(make_arg_typehint_class());
     module.add_class(make_return_typehint_class());
     module.add_class(make_arg_default_value_class());
-    module.add_function("integration_function_typehints", |_| {
-            phper::ok(())
-            },
+    module
+        .add_function("integration_function_typehints", |_| phper::ok(()))
+        .argument(
+            Argument::by_val("s")
+                .with_type_hint(ArgumentTypeHint::String)
+                .with_default_value(CString::new("'foobarbaz'").unwrap()),
         )
-        .argument(Argument::by_val("s").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("'foobarbaz'").unwrap()))
-        .argument(Argument::by_val("i").with_type_hint(ArgumentTypeHint::Int).with_default_value(CString::new("42").unwrap()))
-        .argument(Argument::by_val("f").with_type_hint(ArgumentTypeHint::Float).with_default_value(CString::new("7.89").unwrap()))
-        .argument(Argument::by_val("b").with_type_hint(ArgumentTypeHint::Bool).with_default_value(CString::new("true").unwrap()))
-        .argument(Argument::by_val("a").with_type_hint(ArgumentTypeHint::Array).with_default_value(CString::new("['a'=>'b']").unwrap()))
-        .argument(Argument::by_val("m").with_type_hint(ArgumentTypeHint::Mixed).with_default_value(CString::new("1.23").unwrap()))
+        .argument(
+            Argument::by_val("i")
+                .with_type_hint(ArgumentTypeHint::Int)
+                .with_default_value(CString::new("42").unwrap()),
+        )
+        .argument(
+            Argument::by_val("f")
+                .with_type_hint(ArgumentTypeHint::Float)
+                .with_default_value(CString::new("7.89").unwrap()),
+        )
+        .argument(
+            Argument::by_val("b")
+                .with_type_hint(ArgumentTypeHint::Bool)
+                .with_default_value(CString::new("true").unwrap()),
+        )
+        .argument(
+            Argument::by_val("a")
+                .with_type_hint(ArgumentTypeHint::Array)
+                .with_default_value(CString::new("['a'=>'b']").unwrap()),
+        )
+        .argument(
+            Argument::by_val("m")
+                .with_type_hint(ArgumentTypeHint::Mixed)
+                .with_default_value(CString::new("1.23").unwrap()),
+        )
         .return_type(ReturnType::by_val(ReturnTypeHint::Void));
-
 }
 
 fn make_i_foo_interface() -> InterfaceEntity {
     let mut interface = InterfaceEntity::new(r"IntegrationTest\TypeHints\IFoo");
-    interface.add_method("getValue")
+    interface
+        .add_method("getValue")
         .return_type(ReturnType::by_val(ReturnTypeHint::String));
-    interface.add_method("setValue")
+    interface
+        .add_method("setValue")
         .argument(Argument::by_val("value"));
 
     interface
@@ -56,27 +77,30 @@ fn make_i_foo_interface() -> InterfaceEntity {
 fn make_foo_handler() -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\FooHandler");
 
-    class.add_method("handle", Visibility::Public, |_,arguments| {
-        phper::ok(arguments[0].clone())
-    })
-        .argument(Argument::by_val("foo").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))))
-        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))));
+    class
+        .add_method("handle", Visibility::Public, |_, arguments| {
+            phper::ok(arguments[0].clone())
+        })
+        .argument(
+            Argument::by_val("foo")
+                .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))),
+        )
+        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(
+            String::from(I_FOO),
+        )));
 
     class
 }
 
-fn make_foo_class(
-    i_foo: Interface,
-) -> ClassEntity<()> {
+fn make_foo_class(i_foo: Interface) -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\Foo");
 
-    //leak Interface so that ClassEntry can be retrieved later, during module startup
+    // leak Interface so that ClassEntry can be retrieved later, during module
+    // startup
     let i_foo_copy: &'static Interface = Box::leak(Box::new(i_foo));
-    class.implements(move || {
-        i_foo_copy.as_class_entry()
-    });
+    class.implements(move || i_foo_copy.as_class_entry());
     class
-        .add_method("getValue", Visibility::Public, |this,_| {
+        .add_method("getValue", Visibility::Public, |this, _| {
             let value = this
                 .get_property("value")
                 .expect_z_str()?
@@ -99,23 +123,19 @@ fn make_foo_class(
     class
 }
 
-fn make_b_class(
-    a_class: StateClass<()>,
-    i_foo: Interface,
-) -> ClassEntity<()> {
+fn make_b_class(a_class: StateClass<()>, i_foo: Interface) -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\B");
     let _i_foo_copy: &'static Interface = Box::leak(Box::new(i_foo));
 
-    class
-        .add_static_method("createFoo", Visibility::Public, move |_| {
-            let object = a_class.init_object()?;
-            Ok::<_, phper::Error>(object)
-        });
+    class.add_static_method("createFoo", Visibility::Public, move |_| {
+        let object = a_class.init_object()?;
+        Ok::<_, phper::Error>(object)
+    });
 
     class
 }
 
-fn make_arg_typehint_class() ->ClassEntity<()> {
+fn make_arg_typehint_class() -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ArgumentTypeHintTest");
     // String tests
     class
@@ -126,18 +146,34 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String));
 
     class
-        .add_method("testStringOptional", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
-            phper::ok(())
-        })
-        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).optional());
+        .add_method(
+            "testStringOptional",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("string_value")
+                .with_type_hint(ArgumentTypeHint::String)
+                .optional(),
+        );
 
     class
-        .add_method("testStringNullable", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
-            phper::ok(())
-        })
-        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).allow_null());
+        .add_method(
+            "testStringNullable",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_z_str()?.to_str()?.to_string();
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("string_value")
+                .with_type_hint(ArgumentTypeHint::String)
+                .allow_null(),
+        );
 
     // Bool tests
     class
@@ -148,18 +184,34 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool));
 
     class
-        .add_method("testBoolNullable", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].as_bool();
-            phper::ok(())
-        })
-        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).allow_null());
+        .add_method(
+            "testBoolNullable",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].as_bool();
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("bool_value")
+                .with_type_hint(ArgumentTypeHint::Bool)
+                .allow_null(),
+        );
 
     class
-        .add_method("testBoolOptional", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_bool()?;
-            phper::ok(())
-        })
-        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).optional());
+        .add_method(
+            "testBoolOptional",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_bool()?;
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("bool_value")
+                .with_type_hint(ArgumentTypeHint::Bool)
+                .optional(),
+        );
 
     // Int tests
     class
@@ -170,18 +222,34 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int));
 
     class
-        .add_method("testIntNullable", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_long()?;
-            phper::ok(())
-        })
-        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).allow_null());
+        .add_method(
+            "testIntNullable",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_long()?;
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("int_value")
+                .with_type_hint(ArgumentTypeHint::Int)
+                .allow_null(),
+        );
 
     class
-        .add_method("testIntOptional", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_long()?;
-            phper::ok(())
-        })
-        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).optional());
+        .add_method(
+            "testIntOptional",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_long()?;
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("int_value")
+                .with_type_hint(ArgumentTypeHint::Int)
+                .optional(),
+        );
 
     // Float tests
     class
@@ -192,18 +260,34 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float));
 
     class
-        .add_method("testFloatOptional", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_double()?;
-            phper::ok(())
-        })
-        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).optional());
+        .add_method(
+            "testFloatOptional",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_double()?;
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("float_value")
+                .with_type_hint(ArgumentTypeHint::Float)
+                .optional(),
+        );
 
     class
-        .add_method("testFloatNullable", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_double()?;
-            phper::ok(())
-        })
-        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).allow_null());
+        .add_method(
+            "testFloatNullable",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_double()?;
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("float_value")
+                .with_type_hint(ArgumentTypeHint::Float)
+                .allow_null(),
+        );
 
     // Array tests
     class
@@ -214,120 +298,169 @@ fn make_arg_typehint_class() ->ClassEntity<()> {
         .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array));
 
     class
-        .add_method("testArrayOptional", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_z_arr()?;
-            phper::ok(())
-        })
-        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).optional());
+        .add_method(
+            "testArrayOptional",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_z_arr()?;
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("array_value")
+                .with_type_hint(ArgumentTypeHint::Array)
+                .optional(),
+        );
 
     class
-        .add_method("testArrayNullable", Visibility::Public, move |_, arguments| {
-            let _ = arguments[0].expect_z_arr()?;
-            phper::ok(())
-        })
-        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).allow_null());
+        .add_method(
+            "testArrayNullable",
+            Visibility::Public,
+            move |_, arguments| {
+                let _ = arguments[0].expect_z_arr()?;
+                phper::ok(())
+            },
+        )
+        .argument(
+            Argument::by_val("array_value")
+                .with_type_hint(ArgumentTypeHint::Array)
+                .allow_null(),
+        );
 
     // Mixed tests
     class
-        .add_method("testMixed", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("testMixed", Visibility::Public, move |_, _| phper::ok(()))
         .argument(Argument::by_val("mixed_value").with_type_hint(ArgumentTypeHint::Mixed));
 
     // Callable tests
     class
-        .add_method("testCallable", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method(
+            "testCallable",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
         .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable));
 
     class
         .add_method("testCallableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable).allow_null());
+        .argument(
+            Argument::by_val("callable_value")
+                .with_type_hint(ArgumentTypeHint::Callable)
+                .allow_null(),
+        );
 
     class
         .add_method("testCallableOptional", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("callable_value").with_type_hint(ArgumentTypeHint::Callable).optional());
+        .argument(
+            Argument::by_val("callable_value")
+                .with_type_hint(ArgumentTypeHint::Callable)
+                .optional(),
+        );
 
     class
-        .add_method("testObject", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("testObject", Visibility::Public, move |_, _| phper::ok(()))
         .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object));
 
     class
         .add_method("testObjectNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object).allow_null());
+        .argument(
+            Argument::by_val("object_value")
+                .with_type_hint(ArgumentTypeHint::Object)
+                .allow_null(),
+        );
 
     class
         .add_method("testObjectOptional", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("object_value").with_type_hint(ArgumentTypeHint::Object).optional());
+        .argument(
+            Argument::by_val("object_value")
+                .with_type_hint(ArgumentTypeHint::Object)
+                .optional(),
+        );
 
     class
-        .add_method("testIterable", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method(
+            "testIterable",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
         .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable));
 
     class
         .add_method("testIterableNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).allow_null());
+        .argument(
+            Argument::by_val("iterable_value")
+                .with_type_hint(ArgumentTypeHint::Iterable)
+                .allow_null(),
+        );
 
     class
         .add_method("testIterableOptional", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).optional());
+        .argument(
+            Argument::by_val("iterable_value")
+                .with_type_hint(ArgumentTypeHint::Iterable)
+                .optional(),
+        );
 
     class
-        .add_method("testNull", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("testNull", Visibility::Public, move |_, _| phper::ok(()))
         .argument(Argument::by_val("null_value").with_type_hint(ArgumentTypeHint::Null));
 
     class
         .add_method("testClassEntry", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))));
+        .argument(
+            Argument::by_val("classentry")
+                .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))),
+        );
 
     class
         .add_method("testClassEntryNullable", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))).allow_null());
+        .argument(
+            Argument::by_val("classentry")
+                .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO)))
+                .allow_null(),
+        );
 
     class
         .add_method("testClassEntryOptional", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("classentry").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO))).optional());
+        .argument(
+            Argument::by_val("classentry")
+                .with_type_hint(ArgumentTypeHint::ClassEntry(String::from(I_FOO)))
+                .optional(),
+        );
 
     class
 }
 
-fn make_return_typehint_class() ->ClassEntity<()> {
+fn make_return_typehint_class() -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ReturnTypeHintTest");
     class
-        .add_method("returnNull", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnNull", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Null));
 
     class
-        .add_method("returnString", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method(
+            "returnString",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
         .return_type(ReturnType::by_val(ReturnTypeHint::String));
 
     class
@@ -337,9 +470,7 @@ fn make_return_typehint_class() ->ClassEntity<()> {
         .return_type(ReturnType::by_val(ReturnTypeHint::String).allow_null());
 
     class
-        .add_method("returnBool", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnBool", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Bool));
 
     class
@@ -349,9 +480,7 @@ fn make_return_typehint_class() ->ClassEntity<()> {
         .return_type(ReturnType::by_val(ReturnTypeHint::Bool).allow_null());
 
     class
-        .add_method("returnInt", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnInt", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Int));
 
     class
@@ -361,9 +490,7 @@ fn make_return_typehint_class() ->ClassEntity<()> {
         .return_type(ReturnType::by_val(ReturnTypeHint::Int).allow_null());
 
     class
-        .add_method("returnFloat", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnFloat", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Float));
 
     class
@@ -373,9 +500,7 @@ fn make_return_typehint_class() ->ClassEntity<()> {
         .return_type(ReturnType::by_val(ReturnTypeHint::Float).allow_null());
 
     class
-        .add_method("returnArray", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnArray", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Array));
 
     class
@@ -385,9 +510,11 @@ fn make_return_typehint_class() ->ClassEntity<()> {
         .return_type(ReturnType::by_val(ReturnTypeHint::Array).allow_null());
 
     class
-        .add_method("returnObject", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method(
+            "returnObject",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
         .return_type(ReturnType::by_val(ReturnTypeHint::Object));
 
     class
@@ -421,94 +548,134 @@ fn make_return_typehint_class() ->ClassEntity<()> {
         .return_type(ReturnType::by_val(ReturnTypeHint::Iterable).allow_null());
 
     class
-        .add_method("returnMixed", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnMixed", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Mixed));
 
     class
         .add_method("returnClassEntry", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))));
+        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(
+            String::from(I_FOO),
+        )));
 
     class
-        .add_method("returnClassEntryNullable", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
-        .return_type(ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))).allow_null());
+        .add_method(
+            "returnClassEntryNullable",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
+        .return_type(
+            ReturnType::by_val(ReturnTypeHint::ClassEntry(String::from(I_FOO))).allow_null(),
+        );
 
     class
-        .add_method("returnNever", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnNever", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Never));
 
     class
-        .add_method("returnVoid", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
+        .add_method("returnVoid", Visibility::Public, move |_, _| phper::ok(()))
         .return_type(ReturnType::by_val(ReturnTypeHint::Void));
 
     class
 }
 
-fn make_arg_default_value_class() ->ClassEntity<()> {
+fn make_arg_default_value_class() -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\ArgumentDefaultValueTest");
 
     class
         .add_method("stringDefault", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("string_value").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("'foobarbaz'").unwrap())); //NB single quotes!
+        .argument(
+            Argument::by_val("string_value")
+                .with_type_hint(ArgumentTypeHint::String)
+                .with_default_value(CString::new("'foobarbaz'").unwrap()),
+        ); //NB single quotes!
 
     class
         .add_method("stringConstantDefault", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("const_value").with_type_hint(ArgumentTypeHint::String).with_default_value(CString::new("PHP_VERSION").unwrap()));
+        .argument(
+            Argument::by_val("const_value")
+                .with_type_hint(ArgumentTypeHint::String)
+                .with_default_value(CString::new("PHP_VERSION").unwrap()),
+        );
 
     class
         .add_method("boolDefaultTrue", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).with_default_value(CString::new("true").unwrap()));
+        .argument(
+            Argument::by_val("bool_value")
+                .with_type_hint(ArgumentTypeHint::Bool)
+                .with_default_value(CString::new("true").unwrap()),
+        );
 
     class
         .add_method("boolDefaultFalse", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("bool_value").with_type_hint(ArgumentTypeHint::Bool).with_default_value(CString::new("false").unwrap()));
+        .argument(
+            Argument::by_val("bool_value")
+                .with_type_hint(ArgumentTypeHint::Bool)
+                .with_default_value(CString::new("false").unwrap()),
+        );
 
     class
-        .add_method("intDefault", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
-        .argument(Argument::by_val("int_value").with_type_hint(ArgumentTypeHint::Int).with_default_value(CString::new("42").unwrap()));
+        .add_method("intDefault", Visibility::Public, move |_, _| phper::ok(()))
+        .argument(
+            Argument::by_val("int_value")
+                .with_type_hint(ArgumentTypeHint::Int)
+                .with_default_value(CString::new("42").unwrap()),
+        );
 
     class
-        .add_method("floatDefault", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
-        .argument(Argument::by_val("float_value").with_type_hint(ArgumentTypeHint::Float).with_default_value(CString::new("3.14159").unwrap()));
+        .add_method(
+            "floatDefault",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
+        .argument(
+            Argument::by_val("float_value")
+                .with_type_hint(ArgumentTypeHint::Float)
+                .with_default_value(CString::new("3.14159").unwrap()),
+        );
 
     class
-        .add_method("arrayDefault", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
-        .argument(Argument::by_val("array_value").with_type_hint(ArgumentTypeHint::Array).with_default_value(CString::new("['a' => 'b']").unwrap()));
+        .add_method(
+            "arrayDefault",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
+        .argument(
+            Argument::by_val("array_value")
+                .with_type_hint(ArgumentTypeHint::Array)
+                .with_default_value(CString::new("['a' => 'b']").unwrap()),
+        );
 
     class
         .add_method("iterableDefault", Visibility::Public, move |_, _| {
             phper::ok(())
         })
-        .argument(Argument::by_val("iterable_value").with_type_hint(ArgumentTypeHint::Iterable).with_default_value(CString::new("[0 => 1]").unwrap()));
+        .argument(
+            Argument::by_val("iterable_value")
+                .with_type_hint(ArgumentTypeHint::Iterable)
+                .with_default_value(CString::new("[0 => 1]").unwrap()),
+        );
 
     class
-        .add_method("mixedDefault", Visibility::Public, move |_, _| {
-            phper::ok(())
-        })
-        .argument(Argument::by_val("mixed_value").with_type_hint(ArgumentTypeHint::Mixed).with_default_value(CString::new("999").unwrap()));
+        .add_method(
+            "mixedDefault",
+            Visibility::Public,
+            move |_, _| phper::ok(()),
+        )
+        .argument(
+            Argument::by_val("mixed_value")
+                .with_type_hint(ArgumentTypeHint::Mixed)
+                .with_default_value(CString::new("999").unwrap()),
+        );
 
     class
 }

--- a/tests/integration/tests/integration.rs
+++ b/tests/integration/tests/integration.rs
@@ -42,6 +42,7 @@ fn test_cli() {
             &tests_php_dir.join("references.php"),
             &tests_php_dir.join("errors.php"),
             &tests_php_dir.join("reflection.php"),
+            &tests_php_dir.join("typehints.php"),
         ],
     );
 }

--- a/tests/integration/tests/php/_common.php
+++ b/tests/integration/tests/php/_common.php
@@ -66,3 +66,8 @@ function array_ksort($array) {
     ksort($array);
     return $array;
 }
+
+/* @var string $version Basic php version ('7.0', '8.4') */
+function php_at_least(string $version) {
+    return version_compare(PHP_VERSION, $version, '>=');
+}

--- a/tests/integration/tests/php/_common.php
+++ b/tests/integration/tests/php/_common.php
@@ -28,9 +28,9 @@ function assert_false($value) {
     assert_eq($value, false);
 }
 
-function assert_eq($left, $right) {
+function assert_eq($left, $right, $message = '') {
     if ($left !== $right) {
-        throw new AssertionError(sprintf("left != right,\n left: %s,\n right: %s", var_export($left, true), var_export($right, true)));
+        throw new AssertionError(sprintf("left != right,\n left: %s,\n right: %s,\n message: %s,\n", var_export($left, true), var_export($right, true), $message));
     }
 }
 

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -21,7 +21,7 @@ $value = $foo->getValue();
 assert_eq($value, 'foobar');
 
 $argumentTypehintProvider = [
-    // <method>, <expected typehint>, <is nullable>, <is required>
+    // <method>, <expected typehint>, <is nullable>, <is required>, <(optional)min php version>
     ['testString', 'string', false, true],
     ['testStringOptional', 'string', false, false],
     ['testStringNullable', 'string', true, true],
@@ -56,7 +56,7 @@ $argumentTypehintProvider = [
     ['testIterableOptional', 'iterable', false, false],
     ['testIterableNullable', 'iterable', true, true],
 
-    ['testNull', 'null', true, true],
+    ['testNull', 'null', true, true, '8.2'],
 
     ['testClassEntry', 'class_name', false, true],
     ['testClassEntryOptional', 'class_name', false, false],
@@ -69,6 +69,10 @@ $cls = new \IntegrationTest\TypeHints\ArgumentTypeHintTest();
 $reflection = new ReflectionClass($cls);
 foreach ($argumentTypehintProvider as $input) {
     echo(sprintf("%s..", $input[0]));
+    if (array_key_exists(4, $input) && !php_at_least($input[4])) {
+        echo sprintf("SKIPPED requires at least PHP %s", $input[4]) . PHP_EOL;
+        continue;
+    }
     $reflectionMethod = $reflection->getMethod($input[0]);
     $params = $reflectionMethod->getParameters();
 
@@ -83,8 +87,8 @@ foreach ($argumentTypehintProvider as $input) {
 
 // return typehints
 $returnTypehintProvider = [
-    // <method>, <expected typehint>, <is nullable>
-    ['returnNull', 'null', true],
+    // <method>, <expected typehint>, <is nullable>, <(optional)min php version>
+    ['returnNull', 'null', true, '8.2'],
     ['returnBool', 'bool', false],
     ['returnBoolNullable', 'bool', true],
     ['returnInt', 'int', false],
@@ -102,7 +106,7 @@ $returnTypehintProvider = [
     ['returnIterable', 'iterable', false],
     ['returnIterableNullable', 'iterable', true],
     ['returnMixed', 'mixed', true],
-    ['returnNever', 'never', false],
+    ['returnNever', 'never', false, '8.1'],
     ['returnVoid', 'void', false],
     ['returnClassEntry', 'class_name', false],
     ['returnClassEntryNullable', 'class_name', true],
@@ -112,10 +116,16 @@ $cls = new \IntegrationTest\TypeHints\ReturnTypeHintTest();
 $reflection = new ReflectionClass($cls);
 foreach ($returnTypehintProvider as $input) {
     echo(sprintf("%s..", $input[0]));
+    if (array_key_exists(3, $input) && !php_at_least($input[3])) {
+        echo sprintf("SKIPPED requires at least PHP %s", $input[3]) . PHP_EOL;
+        continue;
+    }
     $reflectionMethod = $reflection->getMethod($input[0]);
     $return = $reflectionMethod->getReturnType();
-    assert_eq($input[1], $return->getName(), sprintf('%s has typehint type', $input[0]));
-    assert_eq($input[2], $return->allowsNull(), sprintf('%s allows null', $input[0]));
+    if ($input[1] !== 'never') {
+        assert_eq($input[1], $return->getName(), sprintf('%s has typehint type', $input[0]));
+        assert_eq($input[2], $return->allowsNull(), sprintf('%s allows null', $input[0]));
+    }
     echo 'PASS' . PHP_EOL;
 }
 

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -58,9 +58,9 @@ $argumentTypehintProvider = [
 
     ['testNull', 'null', true, true, '8.2'],
 
-    ['testClassEntry', 'class_name', false, true, '7.4'],
-    ['testClassEntryOptional', 'class_name', false, false, '7.4'],
-    ['testClassEntryNullable', 'class_name', true, true, '7.4'],
+    ['testClassEntry', 'class_name', false, true, '8.0'],
+    ['testClassEntryOptional', 'class_name', false, false, '8.0'],
+    ['testClassEntryNullable', 'class_name', true, true, '8.0'],
 ];
 
 // typehints
@@ -110,11 +110,11 @@ $returnTypehintProvider = [
     ['returnCallableNullable', 'callable', true],
     ['returnIterable', 'iterable', false],
     ['returnIterableNullable', 'iterable', true],
-    ['returnMixed', 'mixed', true, '7.4'],
+    ['returnMixed', 'mixed', true, '8.0'],
     ['returnNever', 'never', false, '8.1'],
     ['returnVoid', 'void', false],
-    ['returnClassEntry', 'class_name', false, '7.4'],
-    ['returnClassEntryNullable', 'class_name', true, '7.4'],
+    ['returnClassEntry', 'class_name', false, '8.0'],
+    ['returnClassEntryNullable', 'class_name', true, '8.0'],
 ];
 echo PHP_EOL . 'Testing return typehints' . PHP_EOL;
 $cls = new \IntegrationTest\TypeHints\ReturnTypeHintTest();
@@ -155,15 +155,15 @@ if (PHP_VERSION_ID > 70100) {
 
 $argumentDefaultValueProvider = [
     // <method>, <expected default value>, <(optional) min php version>
-    ['stringDefault', 'foobarbaz', 'string', '7.4'],
-    ['stringConstantDefault', PHP_VERSION, 'string', '7.4'],
-    ['boolDefaultTrue', true, 'boolean', '7.4'],
-    ['boolDefaultFalse', false, 'boolean', '7.4'],
-    ['intDefault', 42, 'integer', '7.4'],
-    ['floatDefault', 3.14159, 'double', '7.4'],
-    ['arrayDefault', ['a' => 'b'], 'array', '7.4'],
-    ['iterableDefault', [0 => 1], 'array', '7.4'],
-    ['mixedDefault', 999, 'integer', '7.4'],
+    ['stringDefault', 'foobarbaz', 'string', '8.0'],
+    ['stringConstantDefault', PHP_VERSION, 'string', '8.0'],
+    ['boolDefaultTrue', true, 'boolean', '8.0'],
+    ['boolDefaultFalse', false, 'boolean', '8.0'],
+    ['intDefault', 42, 'integer', '8.0'],
+    ['floatDefault', 3.14159, 'double', '8.0'],
+    ['arrayDefault', ['a' => 'b'], 'array', '8.0'],
+    ['iterableDefault', [0 => 1], 'array', '8.0'],
+    ['mixedDefault', 999, 'integer', '8.0'],
 ];
 
 echo PHP_EOL . 'Testing argument default values' . PHP_EOL;
@@ -194,7 +194,7 @@ $expectedArgs = [
     ['m', 'mixed', 1.23],
 
 ];
-if (PHP_VERSION_ID >= 70400) {
+if (PHP_VERSION_ID >= 80000) {
     echo PHP_EOL . 'Testing function typehints' . PHP_EOL;
     $reflection = new ReflectionFunction('integration_function_typehints');
     $params = $reflection->getParameters();

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -48,9 +48,9 @@ $argumentTypehintProvider = [
     ['testCallableOptional', 'callable', false, false],
     ['testCallableNullable', 'callable', true, true],
 
-    ['testObject', 'object', false, true, '7.1'],
-    ['testObjectOptional', 'object', false, false, '7.1'],
-    ['testObjectNullable', 'object', true, true, '7.1'],
+    ['testObject', 'object', false, true, '7.2'],
+    ['testObjectOptional', 'object', false, false, '7.2'],
+    ['testObjectNullable', 'object', true, true, '7.2'],
 
     ['testIterable', 'iterable', false, true, '7.1'],
     ['testIterableOptional', 'iterable', false, false, '7.1'],
@@ -79,7 +79,7 @@ foreach ($argumentTypehintProvider as $input) {
     assert_eq(1, count($params), 'has 1 param');
     $param = $params[0];
     $type = $param->getType();
-    if (PHP_VERSION_ID >= 70100) {
+    if (PHP_VERSION_ID >= 70200) {
         assert_eq($input[1], (string)$type->getName(), sprintf('%s has typehint type', $input[0]));
         assert_eq($input[2], $type->allowsNull(), sprintf('%s allows null', $input[0]));
         assert_eq($input[3], !$param->isOptional(), sprintf('%s is optional', $input[0]));
@@ -127,7 +127,7 @@ foreach ($returnTypehintProvider as $input) {
     }
     $reflectionMethod = $reflection->getMethod($input[0]);
     $return = $reflectionMethod->getReturnType();
-    if ($input[1] !== 'never' && PHP_VERSION_ID > 70100) {
+    if ($input[1] !== 'never' && PHP_VERSION_ID > 70200) {
         assert_eq($input[1], $return->getName(), sprintf('%s has typehint type', $input[0]));
         assert_eq($input[2], $return->allowsNull(), sprintf('%s allows null', $input[0]));
     }

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -21,7 +21,7 @@ $value = $foo->getValue();
 
 assert_eq($value, 'foobar');
 
-$typehintProvider = [
+$argumentTypehintProvider = [
     // <method>, <expected typehint>, <is nullable>, <is required>
     ['testString', 'string', false, true],
     ['testStringOptional', 'string', false, false],
@@ -58,13 +58,17 @@ $typehintProvider = [
     ['testIterableNullable', 'iterable', true, true],
 
     ['testNull', 'null', true, true],
+
+    ['testClassEntry', 'class_name', false, true],
+    ['testClassEntryOptional', 'class_name', false, false],
+    ['testClassEntryNullable', 'class_name', true, true],
 ];
 
 // typehints
-echo 'Testing TypeHints' . PHP_EOL;
-$c = new \IntegrationTest\TypeHints\C();
-$reflection = new ReflectionClass($c);
-foreach ($typehintProvider as $input) {
+echo 'Testing argument typehints' . PHP_EOL;
+$cls = new \IntegrationTest\TypeHints\ArgumentTypeHintTest();
+$reflection = new ReflectionClass($cls);
+foreach ($argumentTypehintProvider as $input) {
     echo(sprintf("%s..", $input[0]));
     $reflectionMethod = $reflection->getMethod($input[0]);
     $params = $reflectionMethod->getParameters();
@@ -73,9 +77,26 @@ foreach ($typehintProvider as $input) {
     $param = $params[0];
     $type = $param->getType();
     if (!in_array($input[1], ['mixed'])) {
-        assert_eq($input[1], (string)$type->getName(), 'has typehint type');
-        assert_eq($input[2], $type->allowsNull(), 'allows null');
+        assert_eq($input[1], (string)$type->getName(), sprintf('%s has typehint type', $input[0]));
+        assert_eq($input[2], $type->allowsNull(), sprintf('%s allows null', $input[0]));
     }
-    assert_eq($input[3], !$param->isOptional(), 'is optional');
+    assert_eq($input[3], !$param->isOptional(), sprintf('%s is optional', $input[0]));
     echo "PASS" . PHP_EOL;
+}
+
+// return typehints
+$returnTypehintProvider = [
+    // <method>, <expected typehint>, <is nullable>
+    ['returnString', 'string', false],
+];
+echo PHP_EOL . 'Testing return typehints' . PHP_EOL;
+$cls = new \IntegrationTest\TypeHints\ReturnTypeHintTest();
+$reflection = new ReflectionClass($cls);
+foreach ($returnTypehintProvider as $input) {
+    echo(sprintf("%s..", $input[0]));
+    $reflectionMethod = $reflection->getMethod($input[0]);
+    $return = $reflectionMethod->getReturnType();
+    assert_eq($input[1], $return->getName(), sprintf('%s has typehint type', $input[0]));
+    assert_eq($input[2], $return->allowsNull(), sprintf('%s allows null', $input[0]));
+    echo 'PASS' . PHP_EOL;
 }

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -1,0 +1,24 @@
+<?php
+
+// Copyright (c) 2022 PHPER Framework Team
+// PHPER is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan
+// PSL v2. You may obtain a copy of Mulan PSL v2 at:
+//          http://license.coscl.org.cn/MulanPSL2
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
+
+require_once __DIR__ . '/_common.php';
+
+$b = new \IntegrationTest\TypeHints\B();
+$foo = $b->createFoo();
+$foo->setValue('foobar');
+$value = $foo->getValue();
+
+assert_eq($value, 'foobar');
+
+$c = new \IntegrationTest\TypeHints\C();
+assert_eq('foo', $c->handleString('foo'));

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -87,7 +87,28 @@ foreach ($argumentTypehintProvider as $input) {
 // return typehints
 $returnTypehintProvider = [
     // <method>, <expected typehint>, <is nullable>
+    ['returnNull', 'null', true],
+    ['returnBool', 'bool', false],
+    ['returnBoolNullable', 'bool', true],
+    ['returnInt', 'int', false],
+    ['returnIntNullable', 'int', true],
+    ['returnFloat', 'float', false],
+    ['returnFloatNullable', 'float', true],
     ['returnString', 'string', false],
+    ['returnStringNullable', 'string', true],
+    ['returnArray', 'array', false],
+    ['returnArrayNullable', 'array', true],
+    ['returnObject', 'object', false],
+    ['returnObjectNullable', 'object', true],
+    ['returnCallable', 'callable', false],
+    ['returnCallableNullable', 'callable', true],
+    ['returnIterable', 'iterable', false],
+    ['returnIterableNullable', 'iterable', true],
+    ['returnMixed', 'mixed', true],
+    ['returnNever', 'never', false],
+    ['returnVoid', 'void', false],
+    ['returnClassEntry', 'class_name', false],
+    ['returnClassEntryNullable', 'class_name', true],
 ];
 echo PHP_EOL . 'Testing return typehints' . PHP_EOL;
 $cls = new \IntegrationTest\TypeHints\ReturnTypeHintTest();
@@ -100,3 +121,20 @@ foreach ($returnTypehintProvider as $input) {
     assert_eq($input[2], $return->allowsNull(), sprintf('%s allows null', $input[0]));
     echo 'PASS' . PHP_EOL;
 }
+
+// test class entry type-hints with an instance
+$foo = new class implements \IntegrationTest\TypeHints\IFoo {
+    private $value;
+    public function getValue(): string {
+        return $this->value;
+    }
+    public function setValue($value): void {
+        $this->value = $value;
+    }
+};
+
+$foo->setValue('hello');
+assert_eq('hello', $foo->getValue());
+
+$handler = new \IntegrationTest\TypeHints\FooHandler();
+assert_eq($foo, $handler->handle($foo));

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -13,6 +13,7 @@
 
 require_once __DIR__ . '/_common.php';
 
+// class implements module-provided interface
 $b = new \IntegrationTest\TypeHints\B();
 $foo = $b->createFoo();
 $foo->setValue('foobar');
@@ -20,5 +21,61 @@ $value = $foo->getValue();
 
 assert_eq($value, 'foobar');
 
+$typehintProvider = [
+    // <method>, <expected typehint>, <is nullable>, <is required>
+    ['testString', 'string', false, true],
+    ['testStringOptional', 'string', false, false],
+    ['testStringNullable', 'string', true, true],
+
+    ['testInt', 'int', false, true],
+    ['testIntOptional', 'int', false, false],
+    ['testIntNullable', 'int', true, true],
+
+    ['testBool', 'bool', false, true],
+    ['testBoolOptional', 'bool', false, false],
+    ['testBoolNullable', 'bool', true, true],
+
+    ['testFloat', 'float', false, true],
+    ['testFloatOptional', 'float', false, false],
+    ['testFloatNullable', 'float', true, true],
+
+    ['testArray', 'array', false, true],
+    ['testArrayOptional', 'array', false, false],
+    ['testArrayNullable', 'array', true, true],
+
+    ['testMixed', 'mixed', false, true],
+
+    ['testCallable', 'callable', false, true],
+    ['testCallableOptional', 'callable', false, false],
+    ['testCallableNullable', 'callable', true, true],
+
+    ['testObject', 'object', false, true],
+    ['testObjectOptional', 'object', false, false],
+    ['testObjectNullable', 'object', true, true],
+
+    ['testIterable', 'iterable', false, true],
+    ['testIterableOptional', 'iterable', false, false],
+    ['testIterableNullable', 'iterable', true, true],
+
+    ['testNull', 'null', true, true],
+];
+
+// typehints
+echo 'Testing TypeHints' . PHP_EOL;
 $c = new \IntegrationTest\TypeHints\C();
-assert_eq('foo', $c->handleString('foo'));
+$reflection = new ReflectionClass($c);
+foreach ($typehintProvider as $input) {
+    echo(sprintf("%s..", $input[0]));
+    $reflectionMethod = $reflection->getMethod($input[0]);
+    $params = $reflectionMethod->getParameters();
+
+    assert_eq(1, count($params), 'has 1 param');
+    $param = $params[0];
+    $type = $param->getType();
+    if (!in_array($input[1], ['mixed'])) {
+        assert_eq($input[1], (string)$type->getName(), 'has typehint type');
+        assert_eq($input[2], $type->allowsNull(), 'allows null');
+    }
+    assert_eq($input[3], !$param->isOptional(), 'is optional');
+    echo "PASS" . PHP_EOL;
+}


### PR DESCRIPTION
- add types::ArgumentTypeHint and types::ReturnTypeHint
- create interfaces before classes, so that classes can implement interfaces provided by module
- [breaking] ReturnType accepts a ReturnTypeHint instead of a TypeInfo, change argument name from type_info to type_hint
- add API to allow args and return types to be nullable: Argument.allow_null()
- add API to allow arguments to have a default value: Argument.with_default_value(CString)
- tests + documentation updates