### PR TITLE
refactor ClassEntity.implements

### DIFF
--- a/phper-doc/doc/_06_module/_06_register_class/index.md
+++ b/phper-doc/doc/_06_module/_06_register_class/index.md
@@ -41,14 +41,14 @@ class Foo {}
 If you want the class `Foo` extends `Bar`, and implements interface `Stringable`:
 
 ```rust,no_run
-use phper::classes::{ClassEntity, ClassEntry};
+use phper::classes::{ClassEntity, ClassEntry, Interface};
 
 let mut foo = ClassEntity::new("Foo");
 foo.extends(|| ClassEntry::from_globals("Bar").unwrap());
-foo.implements(|| ClassEntry::from_globals("Stringable").unwrap());
+foo.implements(Interface::from_name("Stringable"));
 ```
 
-You should implements the method `Stringable::__toString` after implemented
+You should implement the method `Stringable::__toString` after implementing
 `Stringable`, otherwise the class `Foo` will become abstract class.
 
 ## Add properties

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -11,7 +11,8 @@
 use phper::{
     alloc::RefClone,
     classes::{
-        ClassEntity, ClassEntry, InterfaceEntity, Visibility, array_access_class, iterator_class,
+        ClassEntity, ClassEntry, Interface, InterfaceEntity, Visibility, array_access_class,
+        iterator_class,
     },
     functions::{Argument, ReturnType},
     modules::Module,
@@ -83,8 +84,8 @@ fn integrate_foo(module: &mut Module) {
         array: Default::default(),
     });
 
-    class.implements(iterator_class);
-    class.implements(array_access_class);
+    class.implements(Interface::from_name("Iterator"));
+    class.implements(Interface::from_name("ArrayAccess"));
 
     // Implement Iterator interface.
     class
@@ -228,7 +229,7 @@ fn integrate_stringable(module: &mut Module) {
     use phper::{functions::ReturnType, types::ReturnTypeHint};
 
     let mut cls = ClassEntity::new(r"IntegrationTest\FooString");
-    cls.implements(|| ClassEntry::from_globals("Stringable").unwrap());
+    cls.implements(Interface::from_name("Stringable"));
     cls.add_method("__toString", Visibility::Public, |_this, _: &mut [ZVal]| {
         phper::ok("string")
     })

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -92,11 +92,8 @@ fn make_foo_handler() -> ClassEntity<()> {
 
 fn make_foo_class(i_foo: Interface) -> ClassEntity<()> {
     let mut class = ClassEntity::new(r"IntegrationTest\TypeHints\Foo");
+    class.implements(i_foo);
 
-    // leak Interface so that ClassEntry can be retrieved later, during module
-    // startup
-    let i_foo_copy: &'static Interface = Box::leak(Box::new(i_foo));
-    class.implements(move || i_foo_copy.as_class_entry());
     class
         .add_method("getValue", Visibility::Public, |this, _| {
             let value = this


### PR DESCRIPTION
Instead of taking a function to delay fetching ClassEntry, accept an Interface, and hide the late-fetching