### PR TITLE
feat!: rename `bind_*` to `bound_*`

### DIFF
--- a/phper/src/classes.rs
+++ b/phper/src/classes.rs
@@ -235,7 +235,7 @@ fn find_global_class_entry_ptr(name: impl AsRef<str>) -> *mut zend_class_entry {
 
 /// The [StateClass] holds [zend_class_entry] and inner state, created by
 /// [Module::add_class](crate::modules::Module::add_class) or
-/// [ClassEntity::bind_class].
+/// [ClassEntity::bound_class].
 ///
 /// When the class registered (module initialized), the [StateClass] will
 /// be initialized, so you can use the [StateClass] to new stateful
@@ -436,7 +436,7 @@ pub struct ClassEntity<T: 'static> {
     parent: Option<StateClass<()>>,
     interfaces: Vec<Interface>,
     constants: Vec<ConstantEntity>,
-    bind_class: StateClass<T>,
+    bound_class: StateClass<T>,
     state_cloner: Option<Rc<StateCloner>>,
     _p: PhantomData<(*mut (), T)>,
 }
@@ -474,7 +474,7 @@ impl<T: 'static> ClassEntity<T> {
             parent: None,
             interfaces: Vec::new(),
             constants: Vec::new(),
-            bind_class: StateClass::null(),
+            bound_class: StateClass::null(),
             state_cloner: None,
             _p: PhantomData,
         }
@@ -673,7 +673,7 @@ impl<T: 'static> ClassEntity<T> {
                 parent.cast(),
             );
 
-            self.bind_class.bind(class_ce);
+            self.bound_class.bind(class_ce);
 
             for interface in &self.interfaces {
                 let interface_ce = interface.as_class_entry().as_ptr();
@@ -761,7 +761,7 @@ impl<T: 'static> ClassEntity<T> {
     ///
     /// pub fn make_foo_class() -> ClassEntity<()> {
     ///     let mut class = ClassEntity::<()>::new_with_default_state_constructor("Foo");
-    ///     let foo_class = class.bind_class();
+    ///     let foo_class = class.bound_class();
     ///     class.add_static_method("newInstance", Visibility::Public, move |_| {
     ///         let mut object = foo_class.init_object()?;
     ///         Ok::<_, phper::Error>(object)
@@ -770,8 +770,8 @@ impl<T: 'static> ClassEntity<T> {
     /// }
     /// ```
     #[inline]
-    pub fn bind_class(&self) -> StateClass<T> {
-        self.bind_class.clone()
+    pub fn bound_class(&self) -> StateClass<T> {
+        self.bound_class.clone()
     }
 }
 
@@ -794,7 +794,7 @@ pub struct InterfaceEntity {
     method_entities: Vec<MethodEntity>,
     constants: Vec<ConstantEntity>,
     extends: Vec<Box<dyn Fn() -> &'static ClassEntry>>,
-    bind_interface: Interface,
+    bound_interface: Interface,
 }
 
 impl InterfaceEntity {
@@ -805,7 +805,7 @@ impl InterfaceEntity {
             method_entities: Vec::new(),
             constants: Vec::new(),
             extends: Vec::new(),
-            bind_interface: Interface::null(),
+            bound_interface: Interface::null(),
         }
     }
 
@@ -858,7 +858,7 @@ impl InterfaceEntity {
                 null_mut(),
             );
 
-            self.bind_interface.bind(class_ce);
+            self.bound_interface.bind(class_ce);
 
             for interface in &self.extends {
                 let interface_ce = interface().as_ptr();
@@ -889,8 +889,8 @@ impl InterfaceEntity {
 
     /// Get the bound interface.
     #[inline]
-    pub fn bind_interface(&self) -> Interface {
-        self.bind_interface.clone()
+    pub fn bound_interface(&self) -> Interface {
+        self.bound_interface.clone()
     }
 }
 

--- a/phper/src/modules.rs
+++ b/phper/src/modules.rs
@@ -206,17 +206,17 @@ impl Module {
 
     /// Register class to module.
     pub fn add_class<T>(&mut self, class: ClassEntity<T>) -> StateClass<T> {
-        let bind_class = class.bind_class();
+        let bound_class = class.bound_class();
         self.class_entities
             .push(unsafe { transmute::<ClassEntity<T>, ClassEntity<()>>(class) });
-        bind_class
+        bound_class
     }
 
     /// Register interface to module.
     pub fn add_interface(&mut self, interface: InterfaceEntity) -> Interface {
-        let bind_interface = interface.bind_interface();
+        let bound_interface = interface.bound_interface();
         self.interface_entities.push(interface);
-        bind_interface
+        bound_interface
     }
 
     /// Register constant to module.

--- a/tests/integration/src/classes.rs
+++ b/tests/integration/src/classes.rs
@@ -31,7 +31,7 @@ pub fn integrate(module: &mut Module) {
 
 fn integrate_a(module: &mut Module) {
     let mut class = ClassEntity::new("IntegrationTest\\A");
-    let integrate_a_class = class.bind_class();
+    let integrate_a_class = class.bound_class();
 
     class.add_property("name", Visibility::Private, "default");
     class.add_property("number", Visibility::Private, 100);

--- a/tests/integration/tests/php/classes.php
+++ b/tests/integration/tests/php/classes.php
@@ -29,7 +29,7 @@ $reflection_class = new ReflectionClass(\IntegrationTest\A::class);
 $property_name = $reflection_class->getProperty("name");
 assert_true($property_name->isPrivate());
 
-// Test bind_class
+// Test bound_class
 $a_instance = IntegrationTest\A::newInstance();
 assert_true($a_instance instanceof IntegrationTest\A);
 assert_eq($a_instance->speak(), "name: default, number: 100");


### PR DESCRIPTION
`bound` semantics are more precise.

----

This pull request primarily focuses on renaming several methods and variables in the `phper` library to improve code clarity and consistency. The changes involve renaming the `bind_class` and `bind_interface` methods and variables to `bound_class` and `bound_interface` respectively.

Key changes include:

### Method and Variable Renaming in `phper/src/classes.rs`:

* Renamed `bind_class` to `bound_class` in the `ClassEntity` struct and its methods. [[1]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L439-R439) [[2]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L477-R477) [[3]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L676-R676) [[4]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L764-R764) [[5]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L773-R774)
* Renamed `bind_interface` to `bound_interface` in the `InterfaceEntity` struct and its methods. [[1]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L797-R797) [[2]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L808-R808) [[3]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L861-R861) [[4]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L892-R893)

### Updates in `phper/src/modules.rs`:

* Updated the `add_class` and `add_interface` methods in the `Module` struct to use `bound_class` and `bound_interface` respectively.

### Test Adjustments:

* Modified the test files to reflect the renaming changes in method calls and comments. [[1]](diffhunk://#diff-21b20965a317a67113080df1fd178ec19e351f94366e47abc8da37f7f5c07794L34-R34) [[2]](diffhunk://#diff-78cfaf632647ee1c62495939d2cf738000ae7d813269a6e222ac37e5639eb3c4L32-R32)

These changes ensure that the naming conventions are more intuitive and consistent across the codebase.