### PR TITLE
refactor: optimizing `extends` and `implements`

### DIFF
--- a/phper/src/classes.rs
+++ b/phper/src/classes.rs
@@ -314,7 +314,8 @@ impl<T> StateClass<T> {
 
     /// Converts to class entry.
     pub fn as_class_entry(&self) -> &ClassEntry {
-        match self.inner.borrow().clone() {
+        let inner = self.inner.borrow().clone();
+        match inner {
             InnerClassEntry::Ptr(ptr) => unsafe { ClassEntry::from_ptr(ptr) },
             InnerClassEntry::Name(name) => {
                 let entry = ClassEntry::from_globals(name).unwrap();
@@ -422,7 +423,8 @@ impl Interface {
 
     /// Converts to class entry.
     pub fn as_class_entry(&self) -> &ClassEntry {
-        match self.inner.borrow().clone() {
+        let inner = self.inner.borrow().clone();
+        match inner {
             InnerClassEntry::Ptr(ptr) => unsafe { ClassEntry::from_ptr(ptr) },
             InnerClassEntry::Name(name) => {
                 let entry = ClassEntry::from_globals(name).unwrap();

--- a/phper/src/classes.rs
+++ b/phper/src/classes.rs
@@ -452,7 +452,7 @@ pub struct ClassEntity<T: 'static> {
     state_constructor: Rc<StateConstructor>,
     method_entities: Vec<MethodEntity>,
     property_entities: Vec<PropertyEntity>,
-    parent: Option<StateClass<()>>,
+    parent: Option<StateClass<[()]>>,
     interfaces: Vec<Interface>,
     constants: Vec<ConstantEntity>,
     bound_class: StateClass<T>,
@@ -608,7 +608,7 @@ impl<T: 'static> ClassEntity<T> {
     /// }
     /// ```
     pub fn extends<S: ?Sized>(&mut self, parent: StateClass<S>) {
-        self.parent = Some(unsafe { transmute::<StateClass<S>, StateClass<()>>(parent) });
+        self.parent = Some(unsafe { transmute::<StateClass<S>, StateClass<[()]>>(parent) });
     }
 
     /// Register class to `implements` the interface, due to the class can

--- a/phper/src/classes.rs
+++ b/phper/src/classes.rs
@@ -278,12 +278,12 @@ enum InnerClassEntry {
 ///     module
 /// }
 /// ```
-pub struct StateClass<T> {
+pub struct StateClass<T: ?Sized> {
     inner: Rc<RefCell<InnerClassEntry>>,
     _p: PhantomData<T>,
 }
 
-impl StateClass<()> {
+impl StateClass<[()]> {
     /// Create from name, which will be looked up from globals.
     pub fn from_name(name: impl Into<String>) -> Self {
         Self {
@@ -293,7 +293,7 @@ impl StateClass<()> {
     }
 }
 
-impl<T> StateClass<T> {
+impl<T: ?Sized> StateClass<T> {
     fn null() -> Self {
         Self {
             inner: Rc::new(RefCell::new(InnerClassEntry::Ptr(null()))),
@@ -324,7 +324,9 @@ impl<T> StateClass<T> {
             }
         }
     }
+}
 
+impl<T: 'static> StateClass<T> {
     /// Create the object from class and call `__construct` with arguments.
     ///
     /// If the `__construct` is private, or protected and the called scope isn't
@@ -605,7 +607,7 @@ impl<T: 'static> ClassEntity<T> {
     ///     module
     /// }
     /// ```
-    pub fn extends<S: 'static>(&mut self, parent: StateClass<S>) {
+    pub fn extends<S: ?Sized>(&mut self, parent: StateClass<S>) {
         self.parent = Some(unsafe { transmute::<StateClass<S>, StateClass<()>>(parent) });
     }
 


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to the `phper/src/classes.rs` file. The changes primarily focus on simplifying the handling of `zend_class_entry` pointers by introducing the `InnerClassEntry` enum and updating related structures and methods accordingly.

Key changes include:

### Refactoring of `zend_class_entry` Handling:
* Introduced `InnerClassEntry` enum to encapsulate `zend_class_entry` pointers and names, replacing the previous use of `Rc<RefCell<*mut zend_class_entry>>` and `Option<String>`. [[1]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30R235-R240) [[2]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L277-R290)
* Updated `StateClass` and `Interface` structs to use `InnerClassEntry` for managing `zend_class_entry` pointers and names. [[1]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L277-R290) [[2]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L384-R423)
* Modified methods in `StateClass` and `Interface` to handle the new `InnerClassEntry` structure, including `from_name`, `null`, `bind`, and `as_class_entry`. [[1]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L296-R319) [[2]](diffhunk://#diff-8324153464ddacc297b97bc0162746b0116cf5a2fd7071705ca999cf3b92fe30L384-R423)

### Simplification of Interface Extensions:
* Simplified the `InterfaceEntity` struct by changing the `extends` field to directly store `Interface` instances instead of boxed closures.
* Updated the `extends` method in `InterfaceEntity` to push `Interface` instances directly.
* Adjusted the binding logic in `InterfaceEntity` to use the updated `Interface` structure for class implementations.

### Miscellaneous:
* Consolidated `use` statements for `ptr` module in `phper/src/classes.rs`.