### PR TITLE
chore: update readme and remove dep once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,6 @@ dependencies = [
  "cfg-if",
  "derive_more",
  "indexmap",
- "once_cell",
  "phper-alloc",
  "phper-build",
  "phper-macros",
@@ -1103,7 +1102,6 @@ version = "0.15.0"
 dependencies = [
  "fastcgi-client",
  "libc",
- "once_cell",
  "phper-macros",
  "tempfile",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -24,27 +24,19 @@ The framework that allows us to write PHP extensions using pure and safe Rust wh
 
 ### Tested Support
 
-| **Category**    | **Item** | **Status** |
-| --------------- | -------- | ---------- |
-| **OS**          | Linux    | ✅          |
-|                 | macOS    | ✅          |
-|                 | Windows  | ❌          |
-| **PHP Version** | 7.0      | ✅          |
-|                 | 7.1      | ✅          |
-|                 | 7.2      | ✅          |
-|                 | 7.3      | ✅          |
-|                 | 7.4      | ✅          |
-|                 | 8.0      | ✅          |
-|                 | 8.1      | ✅          |
-|                 | 8.2      | ✅          |
-|                 | 8.3      | ✅          |
-|                 | 8.4      | ✅          |
-| **PHP Mode**    | NTS      | ✅          |
-|                 | ZTS      | ❌          |
-| **SAPI**        | CLI      | ✅          |
-|                 | FPM      | ✅          |
-| **Debug**       | Disable  | ✅          |
-|                 | Enable   | ❌          |
+| **Category**    | **Item**  | **Status** |
+| --------------- | --------- | ---------- |
+| **OS**          | Linux     | ✅          |
+|                 | macOS     | ✅          |
+|                 | Windows   | ❌          |
+| **PHP Version** | 7.0 ~ 7.4 | ✅          |
+|                 | 8.0 ~ 8.4 | ✅          |
+| **PHP Mode**    | NTS       | ✅          |
+|                 | ZTS       | ❌          |
+| **SAPI**        | CLI       | ✅          |
+|                 | FPM       | ✅          |
+| **Debug**       | Disable   | ✅          |
+|                 | Enable    | ❌          |
 
 ## Examples
 
@@ -53,6 +45,8 @@ See [examples](https://github.com/phper-framework/phper/tree/master/examples).
 ## The projects using PHPER
 
 - [apache/skywalking-php](https://github.com/apache/skywalking-php) - The PHP Agent for Apache SkyWalking, which provides the native tracing abilities for PHP project.
+
+- [phper-framework/jieba-php](https://github.com/phper-framework/jieba-php) - The Jieba Chinese Word Segmentation Implemented in Rust Bound for PHP.
 
 ## License
 

--- a/phper-test/Cargo.toml
+++ b/phper-test/Cargo.toml
@@ -22,7 +22,6 @@ license = { workspace = true }
 [dependencies]
 fastcgi-client = "0.9.0"
 libc = "0.2.169"
-once_cell = "1.20.3"
 phper-macros = { workspace = true }
 tempfile = "3.17.1"
 tokio = { version = "1.43.0", features = ["full"] }

--- a/phper-test/src/context.rs
+++ b/phper-test/src/context.rs
@@ -9,7 +9,6 @@
 // See the Mulan PSL v2 for more details.
 
 use crate::utils;
-use once_cell::sync::OnceCell;
 use std::{
     env,
     fs::read_to_string,
@@ -17,6 +16,7 @@ use std::{
     ops::{Deref, DerefMut},
     path::Path,
     process::Command,
+    sync::OnceLock,
 };
 use tempfile::NamedTempFile;
 
@@ -28,7 +28,7 @@ pub struct Context {
 
 impl Context {
     pub fn get_global() -> &'static Context {
-        static CONTEXT: OnceCell<Context> = OnceCell::new();
+        static CONTEXT: OnceLock<Context> = OnceLock::new();
         CONTEXT.get_or_init(|| {
             let mut ini_content = String::new();
 

--- a/phper-test/src/fpm.rs
+++ b/phper-test/src/fpm.rs
@@ -12,19 +12,18 @@
 use crate::{context::Context, utils::spawn_command};
 use fastcgi_client::{Client, Params, Request};
 use libc::{SIGTERM, atexit, kill, pid_t};
-use once_cell::sync::OnceCell;
 use std::{
     fs,
     mem::{ManuallyDrop, forget},
     path::{Path, PathBuf},
     process::Child,
-    sync::Mutex,
+    sync::{Mutex, OnceLock},
     time::Duration,
 };
 use tempfile::NamedTempFile;
 use tokio::{io, net::TcpStream, runtime::Handle, task::block_in_place};
 
-static FPM_HANDLE: OnceCell<Mutex<FpmHandle>> = OnceCell::new();
+static FPM_HANDLE: OnceLock<Mutex<FpmHandle>> = OnceLock::new();
 
 struct FpmHandle {
     lib_path: PathBuf,

--- a/phper/Cargo.toml
+++ b/phper/Cargo.toml
@@ -25,7 +25,6 @@ license = { workspace = true }
 cfg-if = "1.0.0"
 derive_more = { version = "2.0.1", features = ["from", "constructor"] }
 indexmap = "2.7.1"
-once_cell = "1.20.3"
 phper-alloc = { workspace = true }
 phper-macros = { workspace = true }
 phper-sys = { workspace = true }


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve the codebase and update documentation. The most important changes include the replacement of `once_cell` with `OnceLock`, updates to the `README.md` file, and the removal of `once_cell` from `Cargo.toml` dependencies.

### Codebase simplification:

* Replaced `once_cell::sync::OnceCell` with `std::sync::OnceLock` in `phper-test/src/context.rs` and `phper-test/src/fpm.rs`. [[1]](diffhunk://#diff-985da4a1951c31a88d45be3548b1e8f771ee09cedc705dacdf17438569688bdeL12-R19) [[2]](diffhunk://#diff-985da4a1951c31a88d45be3548b1e8f771ee09cedc705dacdf17438569688bdeL31-R31) [[3]](diffhunk://#diff-a13dc704d7da78ff342e7724e7e08be49683efea48818a49db7a2f94d74254b9L15-R26)

### Documentation updates:

* Consolidated PHP version support ranges in the `README.md` file.
* Added a new example link to `phper-framework/jieba-php` in the `README.md` file.

### Dependency management:

* Removed `once_cell` from `phper/Cargo.toml` and `phper-test/Cargo.toml` dependencies. [[1]](diffhunk://#diff-c8b30955a91ac147426dbcaa366e8f2a029db3def8766e656e484e433ba7e66eL28) [[2]](diffhunk://#diff-2679bd57ae8643a94cf1e5b4e5d7b597fe562d6e65be825b428f19e937e535f9L25)