### PR TITLE
fix fpm setup on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,6 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: php-config
 
-      - name: Setup php-fpm for Linux
-        if: matrix.os == 'ubuntu-24.04'
-        run: |
-          find /usr/sbin -name "php-fpm*"
-          sudo apt-get update
-          sudo apt-get install -y php${{ matrix.php-version }}-fpm
-          sudo rm -f /usr/sbin/php-fpm
-          sudo ln -s /usr/sbin/php-fpm${{ matrix.php-version }} /usr/sbin/php-fpm
-
       - name: PHP version
         run: |
           which php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,7 @@ jobs:
       - name: Setup php-fpm for Macos
         if: matrix.os == 'macos-14'
         run: |
-          brew install php@${{ matrix.php-version }}
-          echo "/opt/homebrew/opt/php@${{ matrix.php-version }}/bin" >> "$GITHUB_PATH"
-          echo "/opt/homebrew/opt/php@${{ matrix.php-version }}/sbin" >> "$GITHUB_PATH"
+          find /usr/local -name "php-fpm*"
 
       - name: PHP version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup php-fpm for Linux
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          find /usr -name "php-fpm*"
+          find /usr/sbin -name "php-fpm*"
           sudo apt-get update
           sudo apt-get install -y php${{ matrix.php-version }}-fpm
           sudo rm -f /usr/sbin/php-fpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Setup php-fpm for Linux
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          find /usr/sbin -name "php-fpm*"
           sudo apt-get update
           sudo apt-get install -y php${{ matrix.php-version }}-fpm
           sudo rm -f /usr/sbin/php-fpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,15 @@ jobs:
       - name: Setup php-fpm for Macos
         if: matrix.os == 'macos-14'
         run: |
-          find /usr/local -name "php-fpm*"
+          find /opt/homebrew/Cellar -name "php-fpm*"
 
       - name: PHP version
         run: |
+          which php
           php --version
+          which php-fpm
           php-fpm --version
+          which php-config
           php-config || true
 
           [[ `php --version` == PHP\ ${{ matrix.php-version }}.* ]] || exit 1;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,15 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: php-config
 
+      - name: Setup php-fpm for Linux
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          find /usr/sbin -name "php-fpm*"
+          sudo apt-get update
+          sudo apt-get install -y php${{ matrix.php-version }}-fpm
+          sudo rm -f /usr/sbin/php-fpm
+          sudo ln -s /usr/sbin/php-fpm${{ matrix.php-version }} /usr/sbin/php-fpm
+
       - name: PHP version
         run: |
           which php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,11 @@ jobs:
       - name: Setup php-fpm for Linux
         if: matrix.os == 'ubuntu-24.04'
         run: |
+          find /usr -name "php-fpm*"
           sudo apt-get update
           sudo apt-get install -y php${{ matrix.php-version }}-fpm
           sudo rm -f /usr/sbin/php-fpm
           sudo ln -s /usr/sbin/php-fpm${{ matrix.php-version }} /usr/sbin/php-fpm
-
-      - name: Setup php-fpm for Macos
-        if: matrix.os == 'macos-14'
-        run: |
-          find /opt/homebrew/Cellar -name "php-fpm*"
 
       - name: PHP version
         run: |

--- a/examples/http-client/tests/integration.rs
+++ b/examples/http-client/tests/integration.rs
@@ -32,9 +32,7 @@ pub static TESTS_PHP_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 
 #[test]
 fn test_php() {
-    use std::process::Command;
-    use std::thread::sleep;
-    use std::time::Duration;
+    use std::{process::Command, thread::sleep, time::Duration};
 
     let router = TESTS_PHP_DIR.join("router.php");
     let server = Command::new("php")

--- a/examples/http-client/tests/php/router.php
+++ b/examples/http-client/tests/php/router.php
@@ -1,0 +1,3 @@
+<?php
+header('Content-Type: text/plain');
+echo "Hello phper!";

--- a/examples/http-client/tests/php/router.php
+++ b/examples/http-client/tests/php/router.php
@@ -1,3 +1,14 @@
 <?php
+
+// Copyright (c) 2022 PHPER Framework Team
+// PHPER is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan
+// PSL v2. You may obtain a copy of Mulan PSL v2 at:
+//          http://license.coscl.org.cn/MulanPSL2
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
 header('Content-Type: text/plain');
 echo "Hello phper!";

--- a/examples/http-client/tests/php/test.php
+++ b/examples/http-client/tests/php/test.php
@@ -24,7 +24,7 @@ $client = (new HttpClientBuilder())
     ->cookie_store(true)
     ->build();
 
-$response = $client->get("https://example.com/")->send();
+$response = $client->get("http://localhost:8000/")->send();
 var_dump([
     "status" => $response->status(),
     "headers" => $response->headers(),


### PR DESCRIPTION
Remove the "setup php-fpm" step for macos, since the setup-php step reliably installs php-fpm in a location found by the tests.
Replace `example.com` with a local cli-server endpoint, since macos builds were often failing to reach example.com