### PR TITLE
adding function start and end line number

### DIFF
--- a/phper-doc/doc/_06_module/_02_register_functions/index.md
+++ b/phper-doc/doc/_06_module/_02_register_functions/index.md
@@ -115,7 +115,7 @@ The output of `php --re` for this function would look like:
     Function [ <internal:integration> function my_function ] {
 
       - Parameters [3] {
-        Parameter #0 [ <required> ?class_name $a_class ]
+        Parameter #0 [ <required> ?\MyNamespace\MyInterface $a_class ]
         Parameter #1 [ <optional> string $name = 'my_default' ]
         Parameter #2 [ <optional> bool $optional_bool = <default> ]
       }

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -670,6 +670,17 @@ impl ZFunc {
         }
     }
 
+    /// Gets the line number of the declaration of the currently
+    /// executing function.
+    pub fn get_lineno(&self) -> Option<u32> {
+        unsafe {
+            match u32::from(self.inner.type_) {
+                ZEND_USER_FUNCTION | ZEND_EVAL_CODE => Some(self.inner.op_array.line_start),
+                _ => None,
+            }
+        }
+    }
+
     /// Get the function or method fully-qualified name.
     pub fn get_function_or_method_name(&self) -> ZString {
         unsafe {

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -670,12 +670,23 @@ impl ZFunc {
         }
     }
 
-    /// Gets the line number of the declaration of the currently
+    /// Gets the start line number of the declaration of the currently
     /// executing function.
-    pub fn get_lineno(&self) -> Option<u32> {
+    pub fn get_line_start(&self) -> Option<u32> {
         unsafe {
             match u32::from(self.inner.type_) {
                 ZEND_USER_FUNCTION | ZEND_EVAL_CODE => Some(self.inner.op_array.line_start),
+                _ => None,
+            }
+        }
+    }
+
+    /// Gets the end line number of the declaration of the currently
+    /// executing function.
+    pub fn get_line_end(&self) -> Option<u32> {
+        unsafe {
+            match u32::from(self.inner.type_) {
+                ZEND_USER_FUNCTION | ZEND_EVAL_CODE => Some(self.inner.op_array.line_end),
                 _ => None,
             }
         }

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -133,7 +133,7 @@ impl ExecuteData {
     /// Gets the current opline line number if available. This represents the
     /// line number in the source code where the current operation is being
     /// executed.
-    pub fn get_lineno(&self) -> Option<u32> {
+    pub fn get_opline_lineno(&self) -> Option<u32> {
         unsafe {
             match u32::from((*self.inner.func).type_) {
                 ZEND_USER_FUNCTION | ZEND_EVAL_CODE => {


### PR DESCRIPTION
This pull request introduces improvements to function introspection in the `phper` library and updates documentation to reflect a more accurate parameter type. The most important changes are the addition of new methods for retrieving a function's declaration line numbers, a clarification in a documentation example, and a minor renaming for clarity.

**Function Introspection Enhancements:**

* Added `get_line_start` and `get_line_end` methods to the `ZFunc` struct in `phper/src/functions.rs`, allowing retrieval of the start and end line numbers for user-defined and evaluated functions.

**Documentation Update:**

* Updated the documentation example in `phper-doc/doc/_06_module/_02_register_functions/index.md` to show the parameter type as `?\MyNamespace\MyInterface` instead of `?class_name`, reflecting the actual interface type used.

**Codebase Consistency:**

* Renamed the method `get_lineno` to `get_opline_lineno` in the `ExecuteData` struct in `phper/src/values.rs` for improved clarity regarding its purpose.