### PR TITLE
fix invocation of functions with type hint

### DIFF
--- a/phper-test/src/cli.rs
+++ b/phper-test/src/cli.rs
@@ -179,6 +179,8 @@ pub fn test_php_scripts_with_condition(
                "execute php test command");
 
         if !condition(output) {
+            eprintln!("--- stdout ---\n{}", stdout);
+            eprintln!("--- stderr ---\n{}", stderr);
             panic!("test php file `{}` failed", path);
         }
     }

--- a/phper/src/modules.rs
+++ b/phper/src/modules.rs
@@ -55,6 +55,13 @@ unsafe extern "C" fn module_startup(_type: c_int, module_number: c_int) -> c_int
             interface_entity.init();
         }
 
+        for function_entity in &module.function_entities {
+            module.handler_map.insert(
+                (None, function_entity.name.clone()),
+                function_entity.handler.clone(),
+            );
+        }
+
         for class_entity in &module.class_entities {
             let ce = class_entity.init();
             class_entity.declare_properties(ce);

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -9,12 +9,14 @@
 // See the Mulan PSL v2 for more details.
 
 use phper::{
+    arrays::ZArray,
     classes::{ClassEntity, Interface, InterfaceEntity, StateClass, Visibility},
     functions::{Argument, ReturnType},
     modules::Module,
     types::{ArgumentTypeHint, ReturnTypeHint},
     values::ZVal,
 };
+use std::convert::Infallible;
 
 const I_FOO: &str = r"IntegrationTest\TypeHints\IFoo";
 
@@ -26,6 +28,20 @@ pub fn integrate(module: &mut Module) {
     module.add_class(make_arg_typehint_class());
     module.add_class(make_return_typehint_class());
     module.add_class(make_arg_default_value_class());
+    module.add_function("integration_function_return_bool", |_| -> Result<bool, Infallible> { Ok(true)} )
+        .return_type(ReturnType::new(ReturnTypeHint::Bool));
+    module.add_function("integration_function_return_int", |_| -> Result<i64, Infallible> { Ok(42)} )
+        .return_type(ReturnType::new(ReturnTypeHint::Int));
+    module.add_function("integration_function_return_float", |_| -> Result<f64, Infallible> { Ok(3.14)} )
+        .return_type(ReturnType::new(ReturnTypeHint::Float));
+    module.add_function("integration_function_return_string", |_| -> Result<&'static str, Infallible> { Ok("phper")} )
+        .return_type(ReturnType::new(ReturnTypeHint::String));
+    module.add_function("integration_function_return_array", |_| -> Result<ZArray, Infallible> { Ok(ZArray::new()) } )
+        .return_type(ReturnType::new(ReturnTypeHint::Array));
+    module.add_function("integration_function_return_mixed", |_| -> Result<ZVal, Infallible> { Ok(ZVal::from(1.23))} )
+        .return_type(ReturnType::new(ReturnTypeHint::Mixed));
+    module.add_function("integration_function_return_void", |_| phper::ok(()))
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
     module
         .add_function("integration_function_typehints", |_| phper::ok(()))
         .argument(
@@ -458,7 +474,7 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .add_method(
             "returnString",
             Visibility::Public,
-            move |_, _| phper::ok(()),
+            move |_, _| phper::ok("phper"),
         )
         .return_type(ReturnType::new(ReturnTypeHint::String));
 
@@ -469,7 +485,7 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::String).allow_null());
 
     class
-        .add_method("returnBool", Visibility::Public, move |_, _| phper::ok(()))
+        .add_method("returnBool", Visibility::Public, move |_, _| phper::ok(true))
         .return_type(ReturnType::new(ReturnTypeHint::Bool));
 
     class
@@ -479,7 +495,7 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::Bool).allow_null());
 
     class
-        .add_method("returnInt", Visibility::Public, move |_, _| phper::ok(()))
+        .add_method("returnInt", Visibility::Public, move |_, _| phper::ok(42))
         .return_type(ReturnType::new(ReturnTypeHint::Int));
 
     class
@@ -489,7 +505,7 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::Int).allow_null());
 
     class
-        .add_method("returnFloat", Visibility::Public, move |_, _| phper::ok(()))
+        .add_method("returnFloat", Visibility::Public, move |_, _| phper::ok(3.14))
         .return_type(ReturnType::new(ReturnTypeHint::Float));
 
     class
@@ -499,7 +515,7 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::Float).allow_null());
 
     class
-        .add_method("returnArray", Visibility::Public, move |_, _| phper::ok(()))
+        .add_method("returnArray", Visibility::Public, move |_, _| phper::ok(ZArray::new()))
         .return_type(ReturnType::new(ReturnTypeHint::Array));
 
     class

--- a/tests/integration/src/typehints.rs
+++ b/tests/integration/src/typehints.rs
@@ -28,19 +28,44 @@ pub fn integrate(module: &mut Module) {
     module.add_class(make_arg_typehint_class());
     module.add_class(make_return_typehint_class());
     module.add_class(make_arg_default_value_class());
-    module.add_function("integration_function_return_bool", |_| -> Result<bool, Infallible> { Ok(true)} )
+    module
+        .add_function(
+            "integration_function_return_bool",
+            |_| -> Result<bool, Infallible> { Ok(true) },
+        )
         .return_type(ReturnType::new(ReturnTypeHint::Bool));
-    module.add_function("integration_function_return_int", |_| -> Result<i64, Infallible> { Ok(42)} )
+    module
+        .add_function(
+            "integration_function_return_int",
+            |_| -> Result<i64, Infallible> { Ok(42) },
+        )
         .return_type(ReturnType::new(ReturnTypeHint::Int));
-    module.add_function("integration_function_return_float", |_| -> Result<f64, Infallible> { Ok(3.14)} )
+    module
+        .add_function(
+            "integration_function_return_float",
+            |_| -> Result<f64, Infallible> { Ok(1.234) },
+        )
         .return_type(ReturnType::new(ReturnTypeHint::Float));
-    module.add_function("integration_function_return_string", |_| -> Result<&'static str, Infallible> { Ok("phper")} )
+    module
+        .add_function(
+            "integration_function_return_string",
+            |_| -> Result<&'static str, Infallible> { Ok("phper") },
+        )
         .return_type(ReturnType::new(ReturnTypeHint::String));
-    module.add_function("integration_function_return_array", |_| -> Result<ZArray, Infallible> { Ok(ZArray::new()) } )
+    module
+        .add_function(
+            "integration_function_return_array",
+            |_| -> Result<ZArray, Infallible> { Ok(ZArray::new()) },
+        )
         .return_type(ReturnType::new(ReturnTypeHint::Array));
-    module.add_function("integration_function_return_mixed", |_| -> Result<ZVal, Infallible> { Ok(ZVal::from(1.23))} )
+    module
+        .add_function(
+            "integration_function_return_mixed",
+            |_| -> Result<ZVal, Infallible> { Ok(ZVal::from(1.23)) },
+        )
         .return_type(ReturnType::new(ReturnTypeHint::Mixed));
-    module.add_function("integration_function_return_void", |_| phper::ok(()))
+    module
+        .add_function("integration_function_return_void", |_| phper::ok(()))
         .return_type(ReturnType::new(ReturnTypeHint::Void));
     module
         .add_function("integration_function_typehints", |_| phper::ok(()))
@@ -471,11 +496,9 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::Null));
 
     class
-        .add_method(
-            "returnString",
-            Visibility::Public,
-            move |_, _| phper::ok("phper"),
-        )
+        .add_method("returnString", Visibility::Public, move |_, _| {
+            phper::ok("phper")
+        })
         .return_type(ReturnType::new(ReturnTypeHint::String));
 
     class
@@ -485,7 +508,9 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::String).allow_null());
 
     class
-        .add_method("returnBool", Visibility::Public, move |_, _| phper::ok(true))
+        .add_method("returnBool", Visibility::Public, move |_, _| {
+            phper::ok(true)
+        })
         .return_type(ReturnType::new(ReturnTypeHint::Bool));
 
     class
@@ -505,7 +530,9 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::Int).allow_null());
 
     class
-        .add_method("returnFloat", Visibility::Public, move |_, _| phper::ok(3.14))
+        .add_method("returnFloat", Visibility::Public, move |_, _| {
+            phper::ok(1.234)
+        })
         .return_type(ReturnType::new(ReturnTypeHint::Float));
 
     class
@@ -515,7 +542,9 @@ fn make_return_typehint_class() -> ClassEntity<()> {
         .return_type(ReturnType::new(ReturnTypeHint::Float).allow_null());
 
     class
-        .add_method("returnArray", Visibility::Public, move |_, _| phper::ok(ZArray::new()))
+        .add_method("returnArray", Visibility::Public, move |_, _| {
+            phper::ok(ZArray::new())
+        })
         .return_type(ReturnType::new(ReturnTypeHint::Array));
 
     class

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -210,3 +210,26 @@ if (PHP_VERSION_ID >= 80000) {
     }
     assert_eq('void', $reflection->getReturnType()->getName(), 'integration_function_typehints return type is void');
 }
+
+//invoke type-hinted functions to exercise handlers
+echo PHP_EOL . 'Testing return type-hinted function invocation' . PHP_EOL;
+assert_true(integration_function_return_bool());
+assert_eq(42, integration_function_return_int());
+assert_eq(3.14, integration_function_return_float());
+assert_eq('phper', integration_function_return_string());
+assert_eq(array(), integration_function_return_array());
+assert_eq(1.23, integration_function_return_mixed());
+
+//invoke type-hinted class methods to exercise handlers
+echo PHP_EOL . 'Testing return type-hinted method invocation' . PHP_EOL;
+$cls = new \IntegrationTest\TypeHints\ReturnTypeHintTest();
+assert_eq(true, $cls->returnBool(), 'returnBool');
+assert_eq(null, $cls->returnBoolNullable(), 'returnBoolNullable');
+assert_eq(42, $cls->returnInt(), 'returnInt');
+assert_eq(null, $cls->returnIntNullable(), 'returnIntNullable');
+assert_eq(3.14, $cls->returnFloat(), 'returnFloat');
+assert_eq(null, $cls->returnFloatNullable(), 'returnFloatNullable');
+assert_eq('phper', $cls->returnString(), 'returnString');
+assert_eq(null, $cls->returnStringNullable(), 'returnStringNullable');
+assert_eq(array(), $cls->returnArray(), 'returnArray');
+assert_eq(null, $cls->returnArrayNullable(), 'returnArrayNullable');

--- a/tests/integration/tests/php/typehints.php
+++ b/tests/integration/tests/php/typehints.php
@@ -215,7 +215,7 @@ if (PHP_VERSION_ID >= 80000) {
 echo PHP_EOL . 'Testing return type-hinted function invocation' . PHP_EOL;
 assert_true(integration_function_return_bool());
 assert_eq(42, integration_function_return_int());
-assert_eq(3.14, integration_function_return_float());
+assert_eq(1.234, integration_function_return_float());
 assert_eq('phper', integration_function_return_string());
 assert_eq(array(), integration_function_return_array());
 assert_eq(1.23, integration_function_return_mixed());
@@ -227,7 +227,7 @@ assert_eq(true, $cls->returnBool(), 'returnBool');
 assert_eq(null, $cls->returnBoolNullable(), 'returnBoolNullable');
 assert_eq(42, $cls->returnInt(), 'returnInt');
 assert_eq(null, $cls->returnIntNullable(), 'returnIntNullable');
-assert_eq(3.14, $cls->returnFloat(), 'returnFloat');
+assert_eq(1.234, $cls->returnFloat(), 'returnFloat');
 assert_eq(null, $cls->returnFloatNullable(), 'returnFloatNullable');
 assert_eq('phper', $cls->returnString(), 'returnString');
 assert_eq(null, $cls->returnStringNullable(), 'returnStringNullable');


### PR DESCRIPTION
Previously, storing "mysterious code" in common.arg_info was ok if nothing else was in arg_info. However, when a return type-hint is registered against a function (or anything else that populates arg_info), the slot in arg_info is clobbered by the return type info. Previous tests for adding type-hints appeared correct because they were only inspecting the Reflection of the function, which appeared correct. Only when the function was invoked did it fail to locate the mysterious code, and assume the function was a method and could be found in globals().handler_map (which would panic because function handlers were not globally registered).

To fix this, remove mysterious code entirely, and store function handlers globally, alongside methods and enums.