### PR TITLE
adding functions for interacting with execution context

### DIFF
--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -198,6 +198,10 @@ void phper_zval_str(zval *zv, zend_string *s) {
     ZVAL_STR(zv, s);
 }
 
+void phper_zval_undef(zval *zv) {
+    ZVAL_UNDEF(zv);
+}
+
 void phper_convert_to_long(zval *op) {
     convert_to_long(op);
 }
@@ -451,9 +455,37 @@ uint32_t phper_zend_num_args(const zend_execute_data *execute_data) {
     return ZEND_NUM_ARGS();
 }
 
+uint32_t phper_zend_call_num_args(const zend_execute_data *execute_data) {
+    return ZEND_CALL_NUM_ARGS(execute_data);
+}
+
+void phper_zend_set_call_num_args(zend_execute_data *execute_data, uint32_t num) {
+    ZEND_CALL_NUM_ARGS(execute_data) = num;
+}
+
+uint32_t phper_zend_call_info(zend_execute_data *execute_data) {
+    return ZEND_CALL_INFO(execute_data);
+}
+
+void phper_zend_add_call_flag(zend_execute_data *execute_data, uint32_t flag) {
+    ZEND_ADD_CALL_FLAG(execute_data, flag);
+}
+
+uint32_t phper_zend_call_may_have_undef() {
+    return ZEND_CALL_MAY_HAVE_UNDEF;
+}
+
 bool phper_zend_get_parameters_array_ex(uint32_t param_count,
                                         zval *argument_array) {
     return zend_get_parameters_array_ex(param_count, argument_array) != 0;
+}
+
+int phper_zend_result_success() {
+    return SUCCESS;
+}
+
+int phper_zend_result_failure() {
+    return FAILURE;
 }
 
 // ==================================================

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -348,6 +348,10 @@ zval *phper_get_this(zend_execute_data *execute_data) {
     return getThis();
 }
 
+zend_class_entry *phper_get_called_scope(zend_execute_data *execute_data) {
+    return zend_get_called_scope(execute_data);
+}
+
 size_t phper_zend_object_properties_size(zend_class_entry *ce) {
     return zend_object_properties_size(ce);
 }

--- a/phper-sys/php_wrapper.c
+++ b/phper-sys/php_wrapper.c
@@ -471,13 +471,13 @@ void phper_zend_add_call_flag(zend_execute_data *execute_data, uint32_t flag) {
     ZEND_ADD_CALL_FLAG(execute_data, flag);
 }
 
-uint32_t phper_zend_call_may_have_undef() {
-    return ZEND_CALL_MAY_HAVE_UNDEF;
-}
-
 bool phper_zend_get_parameters_array_ex(uint32_t param_count,
                                         zval *argument_array) {
     return zend_get_parameters_array_ex(param_count, argument_array) != 0;
+}
+
+uint32_t phper_zend_call_may_have_undef() {
+    return ZEND_CALL_MAY_HAVE_UNDEF;
 }
 
 int phper_zend_result_success() {

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -629,6 +629,11 @@ impl ZFunc {
         }
     }
 
+    /// Detects if the function is static.
+    pub fn is_static(&self) -> bool {
+        unsafe { (self.inner.op_array.fn_flags & ZEND_ACC_STATIC) != 0 }
+    }
+
     /// Get the type of the function (sys::ZEND_USER_FUNCTION,
     /// sys::ZEND_INTERNAL_FUNCTION, or sys::ZEND_EVAL_CODE).
     pub fn get_type(&self) -> u32 {

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -191,6 +191,14 @@ impl ExecuteData {
         }
     }
 
+    /// Gets associated called scope if it exists
+    pub fn get_called_scope(&mut self) -> Option<&ZStr> {
+        unsafe {
+            let val = ZVal::from_ptr(phper_get_called_scope(&mut self.inner));
+            val.as_z_str()
+        }
+    }
+
     pub(crate) unsafe fn get_parameters_array(&mut self) -> Vec<ManuallyDrop<ZVal>> {
         unsafe {
             let num_args = self.num_args();

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -209,7 +209,7 @@ impl ExecuteData {
         }
     }
 
-    pub(crate) unsafe fn get_parameters_array(&mut self) -> Vec<ManuallyDrop<ZVal>> {
+    pub unsafe fn get_parameters_array(&mut self) -> Vec<ManuallyDrop<ZVal>> {
         unsafe {
             let num_args = self.num_args();
             let mut arguments = vec![zeroed::<zval>(); num_args];

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -209,7 +209,7 @@ impl ExecuteData {
         }
     }
 
-    pub(crate) unsafe fn get_parameters_array(&mut self) -> Vec<ManuallyDrop<ZVal>> {
+    pub unsafe fn get_parameters_array(&mut self) -> Vec<ManuallyDrop<ZVal>> {
         unsafe {
             let num_args = self.num_args();
             let mut arguments = vec![zeroed::<zval>(); num_args];
@@ -236,18 +236,6 @@ impl ExecuteData {
         unsafe {
             let val = phper_zend_call_var_num(self.as_mut_ptr(), index.try_into().unwrap());
             ZVal::from_mut_ptr(val)
-        }
-    }
-
-    /// Ensure parameter slot exists, if not, create it and set to null.
-    pub fn ensure_parameter_slot(&mut self, index: usize) {
-        let num_args = self.num_args();
-        if index >= num_args {
-            unsafe {
-                let params_ptr = phper_zend_call_var_num(self.as_mut_ptr(), index as i32);
-                phper_zval_null(params_ptr);
-                (*self.inner.func).common.num_args = (index + 1) as u32;
-            }
         }
     }
 }

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -187,8 +187,13 @@ impl ExecuteData {
     /// Gets associated mutable `$this` object if exists.
     pub fn get_this_mut(&mut self) -> Option<&mut ZObj> {
         unsafe {
-            let val = ZVal::from_mut_ptr(phper_get_this(&mut self.inner));
-            val.as_mut_z_obj()
+            let ptr = phper_get_this(&mut self.inner);
+            if ptr.is_null() {
+                None
+            } else {
+                let val = ZVal::from_mut_ptr(ptr);
+                val.as_mut_z_obj()
+            }
         }
     }
 

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -179,21 +179,14 @@ impl ExecuteData {
     /// Gets associated `$this` object if exists.
     pub fn get_this(&mut self) -> Option<&ZObj> {
         unsafe {
-            let val = ZVal::from_ptr(phper_get_this(&mut self.inner));
-            val.as_z_obj()
+            ZVal::try_from_ptr(phper_get_this(&mut self.inner))?.as_z_obj()
         }
     }
 
     /// Gets associated mutable `$this` object if exists.
     pub fn get_this_mut(&mut self) -> Option<&mut ZObj> {
         unsafe {
-            let ptr = phper_get_this(&mut self.inner);
-            if ptr.is_null() {
-                None
-            } else {
-                let val = ZVal::from_mut_ptr(ptr);
-                val.as_mut_z_obj()
-            }
+            ZVal::try_from_mut_ptr(phper_get_this(&mut self.inner))?.as_mut_z_obj()
         }
     }
 
@@ -209,7 +202,7 @@ impl ExecuteData {
         }
     }
 
-    pub unsafe fn get_parameters_array(&mut self) -> Vec<ManuallyDrop<ZVal>> {
+    pub(crate) unsafe fn get_parameters_array(&mut self) -> Vec<ManuallyDrop<ZVal>> {
         unsafe {
             let num_args = self.num_args();
             let mut arguments = vec![zeroed::<zval>(); num_args];

--- a/phper/src/values.rs
+++ b/phper/src/values.rs
@@ -12,6 +12,7 @@
 
 use crate::{
     arrays::{ZArr, ZArray},
+    classes::ClassEntry,
     errors::ExpectTypeError,
     functions::{ZFunc, call_internal},
     objects::{StateObject, ZObj, ZObject},
@@ -192,10 +193,14 @@ impl ExecuteData {
     }
 
     /// Gets associated called scope if it exists
-    pub fn get_called_scope(&mut self) -> Option<&ZStr> {
+    pub fn get_called_scope(&mut self) -> Option<&ClassEntry> {
         unsafe {
-            let val = ZVal::from_ptr(phper_get_called_scope(&mut self.inner));
-            val.as_z_str()
+            let ptr = phper_get_called_scope(&mut self.inner);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(ClassEntry::from_ptr(ptr))
+            }
         }
     }
 


### PR DESCRIPTION
This pull request adds new FFI (Foreign Function Interface) wrappers and Rust-side helpers for working with PHP internals, particularly around function and execution context introspection. The changes improve the ability to interact with PHP's call stack, function flags, and class scopes from Rust code, and also provide more ergonomic and safe APIs.

**New PHP internals FFI wrappers:**

* Added `phper_zval_undef` to set a `zval` to `UNDEF` and exposed it to Rust.
* Added wrappers for call stack introspection: `phper_get_called_scope`, `phper_zend_call_num_args`, `phper_zend_set_call_num_args`, `phper_zend_call_info`, `phper_zend_add_call_flag`, and `phper_zend_call_may_have_undef`. Also added helpers for success/failure constants. [[1]](diffhunk://#diff-480f823e759f544bf2c3bce93a8a4579735e34a8e3bb835ec6e754fda3af6fd3R355-R358) [[2]](diffhunk://#diff-480f823e759f544bf2c3bce93a8a4579735e34a8e3bb835ec6e754fda3af6fd3R458-R490)

**Rust-side enhancements:**

* Added `is_static` method to `ZFunc` to check if a function is static using `ZEND_ACC_STATIC`.
* Improved `ExecuteData::get_this` and `get_this_mut` to use safe pointer conversion and added `get_called_scope` to retrieve the called class scope as an optional `ClassEntry`.
* Updated module imports in `phper/src/values.rs` to include `ClassEntry` for new functionality.
