### PR TITLE
Refactor type hints, improve CI workflows, and enhance safety comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install libclang for Linux
         if: matrix.os == 'ubuntu-24.04'
@@ -95,14 +95,13 @@ jobs:
           [[ `php-config --version` == ${{ matrix.php-version }}.* ]] || exit 1;
           [[ `php-fpm --version` == PHP\ ${{ matrix.php-version }}.* ]] || exit 1;
 
-      - name: Install Rust Nightly
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Setup cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -113,29 +112,15 @@ jobs:
           key: ${{ matrix.os }}-ci-${{ matrix.php-version }}-ts-${{ matrix.ts }}-debug-${{ matrix.debug }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly
-          command: fmt
-          args: --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --release
+        run: cargo clippy --release
 
       - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release -- --nocapture
+        run: cargo test --release -- --nocapture
 
       - name: Cargo doc
-        uses: actions-rs/cargo@v1
+        run: cargo +nightly doc --workspace --no-deps --all-features
         env:
           RUSTDOCFLAGS: "-D warnings --cfg docsrs"
-        with:
-          toolchain: nightly
-          command: doc
-          args: --workspace --no-deps --all-features

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check License Header
         uses: apache/skywalking-eyes/header/@d5466651aaded6fbd588d2278eccc469afc89d92
         with:

--- a/phper-macros/src/derives.rs
+++ b/phper-macros/src/derives.rs
@@ -7,3 +7,5 @@
 // KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 // NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 // See the Mulan PSL v2 for more details.
+
+// TODO Implement derive macros (e.g. `#[derive(ZValConvert)]`).

--- a/phper-macros/src/lib.rs
+++ b/phper-macros/src/lib.rs
@@ -13,8 +13,8 @@
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/112468984?s=200&v=4")]
 
-// TODO Write a bridge macro for easy usage about register functions and
-// classes, like `cxx`.
+// TODO Implement a bridge macro (similar to `cxx`) to simplify registering
+// functions and classes with less boilerplate.
 
 mod alloc;
 mod derives;

--- a/phper-sys/build.rs
+++ b/phper-sys/build.rs
@@ -72,7 +72,12 @@ fn execute_command<S: AsRef<OsStr> + Debug>(argv: &[S]) -> String {
     command.args(&argv[1..]);
     let output = command
         .output()
-        .unwrap_or_else(|_| panic!("Execute command {:?} failed", &argv))
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to execute `{:?}`: {}. Is php-config installed and in PATH?",
+                &argv, e
+            )
+        })
         .stdout;
     String::from_utf8(output).unwrap().trim().to_owned()
 }

--- a/phper-sys/src/lib.rs
+++ b/phper-sys/src/lib.rs
@@ -15,7 +15,14 @@
 #![allow(non_snake_case)]
 // TODO Because `bindgen` generates codes contains deref nullptr, temporary suppression.
 #![allow(deref_nullptr)]
-#![allow(clippy::all)]
+// Allow specific clippy lints triggered by bindgen-generated code.
+#![allow(
+    clippy::missing_safety_doc,
+    clippy::too_many_arguments,
+    clippy::useless_transmute,
+    clippy::redundant_static_lifetimes,
+    clippy::unreadable_literal
+)]
 // TODO unsafe_op_in_unsafe_fn warning in edition 2024, temporary suppression.
 #![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]

--- a/phper-sys/src/lib.rs
+++ b/phper-sys/src/lib.rs
@@ -21,7 +21,8 @@
     clippy::too_many_arguments,
     clippy::useless_transmute,
     clippy::redundant_static_lifetimes,
-    clippy::unreadable_literal
+    clippy::unreadable_literal,
+    clippy::ptr_offset_with_cast
 )]
 // TODO unsafe_op_in_unsafe_fn warning in edition 2024, temporary suppression.
 #![allow(unsafe_op_in_unsafe_fn)]

--- a/phper/src/errors.rs
+++ b/phper/src/errors.rs
@@ -29,30 +29,32 @@ use std::{
 };
 
 /// Helper macro to delegate `Throwable` trait methods for the `Error` enum.
+///
+/// Call with `& self` for shared-reference methods, or `& mut self` for
+/// mutable-reference methods.
 macro_rules! throwable_delegate {
-    // For `&mut self` method (to_object) - must come first since it's the
-    // most specific pattern.
-    ($self:expr,to_object) => {
-        match $self {
-            Self::Io(e) => Throwable::to_object(e as &mut dyn error::Error),
-            Self::Utf8(e) => Throwable::to_object(e as &mut dyn error::Error),
-            Self::FromBytesWithNul(e) => Throwable::to_object(e as &mut dyn error::Error),
-            Self::Boxed(e) => Throwable::to_object(e.deref_mut()),
-            Self::Throw(e) => Throwable::to_object(e),
-            Self::ClassNotFound(e) => Throwable::to_object(e),
-            Self::ArgumentCount(e) => Throwable::to_object(e),
-            Self::InitializeObject(e) => Throwable::to_object(e),
-            Self::ExpectType(e) => Throwable::to_object(e),
-            Self::NotImplementThrowable(e) => Throwable::to_object(e),
-        }
-    };
     // For `&self` methods (get_class, get_code, get_message).
-    ($self:expr, $method:ident) => {
+    ($self:expr, &self, $method:ident) => {
         match $self {
             Self::Io(e) => Throwable::$method(e as &dyn error::Error),
             Self::Utf8(e) => Throwable::$method(e as &dyn error::Error),
             Self::FromBytesWithNul(e) => Throwable::$method(e as &dyn error::Error),
             Self::Boxed(e) => Throwable::$method(e.deref()),
+            Self::Throw(e) => Throwable::$method(e),
+            Self::ClassNotFound(e) => Throwable::$method(e),
+            Self::ArgumentCount(e) => Throwable::$method(e),
+            Self::InitializeObject(e) => Throwable::$method(e),
+            Self::ExpectType(e) => Throwable::$method(e),
+            Self::NotImplementThrowable(e) => Throwable::$method(e),
+        }
+    };
+    // For `&mut self` methods (to_object).
+    ($self:expr, &mut self, $method:ident) => {
+        match $self {
+            Self::Io(e) => Throwable::$method(e as &mut dyn error::Error),
+            Self::Utf8(e) => Throwable::$method(e as &mut dyn error::Error),
+            Self::FromBytesWithNul(e) => Throwable::$method(e as &mut dyn error::Error),
+            Self::Boxed(e) => Throwable::$method(e.deref_mut()),
             Self::Throw(e) => Throwable::$method(e),
             Self::ClassNotFound(e) => Throwable::$method(e),
             Self::ArgumentCount(e) => Throwable::$method(e),
@@ -263,19 +265,19 @@ impl Error {
 
 impl Throwable for Error {
     fn get_class(&self) -> &ClassEntry {
-        throwable_delegate!(self, get_class)
+        throwable_delegate!(self, &self, get_class)
     }
 
     fn get_code(&self) -> Option<i64> {
-        throwable_delegate!(self, get_code)
+        throwable_delegate!(self, &self, get_code)
     }
 
     fn get_message(&self) -> Option<String> {
-        throwable_delegate!(self, get_message)
+        throwable_delegate!(self, &self, get_message)
     }
 
     fn to_object(&mut self) -> result::Result<ZObject, Box<dyn Throwable>> {
-        throwable_delegate!(self, to_object)
+        throwable_delegate!(self, &mut self, to_object)
     }
 }
 

--- a/phper/src/errors.rs
+++ b/phper/src/errors.rs
@@ -28,6 +28,41 @@ use std::{
     str::Utf8Error,
 };
 
+/// Helper macro to delegate `Throwable` trait methods for the `Error` enum.
+macro_rules! throwable_delegate {
+    // For `&mut self` method (to_object) - must come first since it's the
+    // most specific pattern.
+    ($self:expr,to_object) => {
+        match $self {
+            Self::Io(e) => Throwable::to_object(e as &mut dyn error::Error),
+            Self::Utf8(e) => Throwable::to_object(e as &mut dyn error::Error),
+            Self::FromBytesWithNul(e) => Throwable::to_object(e as &mut dyn error::Error),
+            Self::Boxed(e) => Throwable::to_object(e.deref_mut()),
+            Self::Throw(e) => Throwable::to_object(e),
+            Self::ClassNotFound(e) => Throwable::to_object(e),
+            Self::ArgumentCount(e) => Throwable::to_object(e),
+            Self::InitializeObject(e) => Throwable::to_object(e),
+            Self::ExpectType(e) => Throwable::to_object(e),
+            Self::NotImplementThrowable(e) => Throwable::to_object(e),
+        }
+    };
+    // For `&self` methods (get_class, get_code, get_message).
+    ($self:expr, $method:ident) => {
+        match $self {
+            Self::Io(e) => Throwable::$method(e as &dyn error::Error),
+            Self::Utf8(e) => Throwable::$method(e as &dyn error::Error),
+            Self::FromBytesWithNul(e) => Throwable::$method(e as &dyn error::Error),
+            Self::Boxed(e) => Throwable::$method(e.deref()),
+            Self::Throw(e) => Throwable::$method(e),
+            Self::ClassNotFound(e) => Throwable::$method(e),
+            Self::ArgumentCount(e) => Throwable::$method(e),
+            Self::InitializeObject(e) => Throwable::$method(e),
+            Self::ExpectType(e) => Throwable::$method(e),
+            Self::NotImplementThrowable(e) => Throwable::$method(e),
+        }
+    };
+}
+
 /// Predefined interface `Throwable`.
 #[inline]
 pub fn throwable_class<'a>() -> &'a ClassEntry {
@@ -227,66 +262,20 @@ impl Error {
 }
 
 impl Throwable for Error {
-    #[inline]
     fn get_class(&self) -> &ClassEntry {
-        match self {
-            Error::Io(e) => Throwable::get_class(e as &dyn error::Error),
-            Error::Utf8(e) => Throwable::get_class(e as &dyn error::Error),
-            Error::FromBytesWithNul(e) => Throwable::get_class(e as &dyn error::Error),
-            Error::Boxed(e) => Throwable::get_class(e.deref()),
-            Error::Throw(e) => Throwable::get_class(e),
-            Error::ClassNotFound(e) => Throwable::get_class(e),
-            Error::ArgumentCount(e) => Throwable::get_class(e),
-            Error::InitializeObject(e) => Throwable::get_class(e),
-            Error::ExpectType(e) => Throwable::get_class(e),
-            Error::NotImplementThrowable(e) => Throwable::get_class(e),
-        }
+        throwable_delegate!(self, get_class)
     }
 
-    #[inline]
     fn get_code(&self) -> Option<i64> {
-        match self {
-            Error::Io(e) => Throwable::get_code(e as &dyn error::Error),
-            Error::Utf8(e) => Throwable::get_code(e as &dyn error::Error),
-            Error::FromBytesWithNul(e) => Throwable::get_code(e as &dyn error::Error),
-            Error::Boxed(e) => Throwable::get_code(e.deref()),
-            Error::Throw(e) => Throwable::get_code(e),
-            Error::ClassNotFound(e) => Throwable::get_code(e),
-            Error::ArgumentCount(e) => Throwable::get_code(e),
-            Error::InitializeObject(e) => Throwable::get_code(e),
-            Error::ExpectType(e) => Throwable::get_code(e),
-            Error::NotImplementThrowable(e) => Throwable::get_code(e),
-        }
+        throwable_delegate!(self, get_code)
     }
 
     fn get_message(&self) -> Option<String> {
-        match self {
-            Error::Io(e) => Throwable::get_message(e as &dyn error::Error),
-            Error::Utf8(e) => Throwable::get_message(e as &dyn error::Error),
-            Error::FromBytesWithNul(e) => Throwable::get_message(e as &dyn error::Error),
-            Error::Boxed(e) => Throwable::get_message(e.deref()),
-            Error::Throw(e) => Throwable::get_message(e),
-            Error::ClassNotFound(e) => Throwable::get_message(e),
-            Error::ArgumentCount(e) => Throwable::get_message(e),
-            Error::InitializeObject(e) => Throwable::get_message(e),
-            Error::ExpectType(e) => Throwable::get_message(e),
-            Error::NotImplementThrowable(e) => Throwable::get_message(e),
-        }
+        throwable_delegate!(self, get_message)
     }
 
     fn to_object(&mut self) -> result::Result<ZObject, Box<dyn Throwable>> {
-        match self {
-            Error::Io(e) => Throwable::to_object(e as &mut dyn error::Error),
-            Error::Utf8(e) => Throwable::to_object(e as &mut dyn error::Error),
-            Error::FromBytesWithNul(e) => Throwable::to_object(e as &mut dyn error::Error),
-            Error::Boxed(e) => Throwable::to_object(e.deref_mut()),
-            Error::Throw(e) => Throwable::to_object(e),
-            Error::ClassNotFound(e) => Throwable::to_object(e),
-            Error::ArgumentCount(e) => Throwable::to_object(e),
-            Error::InitializeObject(e) => Throwable::to_object(e),
-            Error::ExpectType(e) => Throwable::to_object(e),
-            Error::NotImplementThrowable(e) => Throwable::to_object(e),
-        }
+        throwable_delegate!(self, to_object)
     }
 }
 

--- a/phper/src/functions.rs
+++ b/phper/src/functions.rs
@@ -10,7 +10,7 @@
 
 //! Apis relate to [zend_function_entry].
 //!
-//! TODO Add lambda.
+//! TODO Add support for closures / lambda functions.
 
 use crate::{
     classes::{ClassEntry, RawVisibility, Visibility},
@@ -138,89 +138,26 @@ impl FunctionEntry {
         name: &CStr, arguments: &[Argument], return_type: Option<&ReturnType>,
         handler: Option<Rc<dyn Callable>>, visibility: Option<RawVisibility>,
     ) -> zend_function_entry {
-        unsafe {
-            let mut infos = Vec::new();
+        let mut infos = Vec::new();
 
-            let require_arg_count = arguments.iter().filter(|arg| arg.required).count();
+        let require_arg_count = arguments.iter().filter(|arg| arg.required).count();
 
-            let return_info = if let Some(return_type) = return_type {
-                match &return_type.type_hint {
-                    ReturnTypeHint::Null => Some(phper_zend_begin_arg_with_return_type_info_ex(
+        // Build return type info.
+        let return_info = if let Some(return_type) = return_type {
+            match &return_type.type_hint {
+                ReturnTypeHint::Null => unsafe {
+                    Some(phper_zend_begin_arg_with_return_type_info_ex(
                         false,
                         require_arg_count,
                         IS_NULL,
                         true,
-                    )),
-                    ReturnTypeHint::Bool => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        _IS_BOOL,
-                        return_type.allow_null,
-                    )),
-                    ReturnTypeHint::Int => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        IS_LONG,
-                        return_type.allow_null,
-                    )),
-                    ReturnTypeHint::Float => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        IS_DOUBLE,
-                        return_type.allow_null,
-                    )),
-                    ReturnTypeHint::String => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        IS_STRING,
-                        return_type.allow_null,
-                    )),
-                    ReturnTypeHint::Array => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        IS_ARRAY,
-                        return_type.allow_null,
-                    )),
-                    ReturnTypeHint::Object => Some(phper_zend_begin_arg_with_return_type_info_ex(
-                        return_type.ret_by_ref,
-                        require_arg_count,
-                        IS_OBJECT,
-                        return_type.allow_null,
-                    )),
-                    ReturnTypeHint::Callable => {
-                        Some(phper_zend_begin_arg_with_return_type_info_ex(
-                            return_type.ret_by_ref,
-                            require_arg_count,
-                            IS_CALLABLE,
-                            return_type.allow_null,
-                        ))
-                    }
-                    ReturnTypeHint::Iterable => {
-                        Some(phper_zend_begin_arg_with_return_type_info_ex(
-                            return_type.ret_by_ref,
-                            require_arg_count,
-                            IS_ITERABLE,
-                            return_type.allow_null,
-                        ))
-                    }
-                    ReturnTypeHint::Mixed => {
-                        if PHP_MAJOR_VERSION < 8 {
-                            None
-                        } else {
-                            Some(phper_zend_begin_arg_with_return_type_info_ex(
-                                return_type.ret_by_ref,
-                                require_arg_count,
-                                IS_MIXED,
-                                true,
-                            ))
-                        }
-                    }
-                    ReturnTypeHint::Never => {
-                        if PHP_MAJOR_VERSION < 8
-                            || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION < 2)
-                        {
-                            None
-                        } else {
+                    ))
+                },
+                ReturnTypeHint::Never => {
+                    if PHP_MAJOR_VERSION < 8 || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION < 2) {
+                        None
+                    } else {
+                        unsafe {
                             Some(phper_zend_begin_arg_with_return_type_info_ex(
                                 return_type.ret_by_ref,
                                 require_arg_count,
@@ -229,15 +166,18 @@ impl FunctionEntry {
                             ))
                         }
                     }
-                    ReturnTypeHint::Void => Some(phper_zend_begin_arg_with_return_type_info_ex(
+                }
+                ReturnTypeHint::Void => unsafe {
+                    Some(phper_zend_begin_arg_with_return_type_info_ex(
                         return_type.ret_by_ref,
                         require_arg_count,
                         IS_VOID,
                         false,
-                    )),
-                    ReturnTypeHint::ClassEntry(class_name) => {
-                        let class_name =
-                            CString::new(class_name.clone()).expect("CString::new failed");
+                    ))
+                },
+                ReturnTypeHint::ClassEntry(class_name) => {
+                    let class_name = CString::new(class_name.clone()).expect("CString::new failed");
+                    unsafe {
                         Some(phper_zend_begin_arg_with_return_obj_info_ex(
                             return_type.ret_by_ref,
                             require_arg_count,
@@ -246,94 +186,42 @@ impl FunctionEntry {
                         ))
                     }
                 }
-            } else {
-                None
-            };
+                hint => hint.zend_type_const().map(|type_const| unsafe {
+                    let allow_null = match hint {
+                        ReturnTypeHint::Mixed => true,
+                        _ => return_type.allow_null,
+                    };
+                    phper_zend_begin_arg_with_return_type_info_ex(
+                        return_type.ret_by_ref,
+                        require_arg_count,
+                        type_const,
+                        allow_null,
+                    )
+                }),
+            }
+        } else {
+            None
+        };
 
-            infos.push(
-                return_info
-                    .unwrap_or_else(|| phper_zend_begin_arg_info_ex(false, require_arg_count)),
-            );
+        infos.push(
+            return_info.unwrap_or_else(|| unsafe {
+                phper_zend_begin_arg_info_ex(false, require_arg_count)
+            }),
+        );
 
-            for arg in arguments {
-                let default_value_ptr = arg
-                    .default_value
-                    .as_ref()
-                    .map(|s| s.as_ptr())
-                    .unwrap_or(std::ptr::null());
-                let arg_info = if let Some(ref type_hint) = arg.type_hint {
-                    match type_hint {
-                        ArgumentTypeHint::Null => Some(phper_zend_arg_info_with_type(
-                            arg.pass_by_ref,
-                            arg.name.as_ptr(),
-                            IS_NULL,
-                            true,
-                            default_value_ptr,
-                        )),
-                        ArgumentTypeHint::Bool => Some(phper_zend_arg_info_with_type(
-                            arg.pass_by_ref,
-                            arg.name.as_ptr(),
-                            _IS_BOOL,
-                            arg.nullable,
-                            default_value_ptr,
-                        )),
-                        ArgumentTypeHint::Int => Some(phper_zend_arg_info_with_type(
-                            arg.pass_by_ref,
-                            arg.name.as_ptr(),
-                            IS_LONG,
-                            arg.nullable,
-                            default_value_ptr,
-                        )),
-                        ArgumentTypeHint::Float => Some(phper_zend_arg_info_with_type(
-                            arg.pass_by_ref,
-                            arg.name.as_ptr(),
-                            IS_DOUBLE,
-                            arg.nullable,
-                            default_value_ptr,
-                        )),
-                        ArgumentTypeHint::String => Some(phper_zend_arg_info_with_type(
-                            arg.pass_by_ref,
-                            arg.name.as_ptr(),
-                            IS_STRING,
-                            arg.nullable,
-                            default_value_ptr,
-                        )),
-                        ArgumentTypeHint::Array => Some(phper_zend_arg_info_with_type(
-                            arg.pass_by_ref,
-                            arg.name.as_ptr(),
-                            IS_ARRAY,
-                            arg.nullable,
-                            default_value_ptr,
-                        )),
-                        ArgumentTypeHint::Object => Some(
-                            phper_zend_arg_info_with_type(
-                                arg.pass_by_ref,
-                                arg.name.as_ptr(),
-                                IS_OBJECT,
-                                arg.nullable,
-                                std::ptr::null(),
-                            ), // default value not supported
-                        ),
-                        ArgumentTypeHint::Callable => Some(
-                            phper_zend_arg_info_with_type(
-                                arg.pass_by_ref,
-                                arg.name.as_ptr(),
-                                IS_CALLABLE,
-                                arg.nullable,
-                                std::ptr::null(),
-                            ), // default value not supported
-                        ),
-                        ArgumentTypeHint::Iterable => Some(phper_zend_arg_info_with_type(
-                            arg.pass_by_ref,
-                            arg.name.as_ptr(),
-                            IS_ITERABLE,
-                            arg.nullable,
-                            default_value_ptr,
-                        )),
-                        ArgumentTypeHint::Mixed => {
-                            if PHP_MAJOR_VERSION < 8 {
-                                None
-                            } else {
+        for arg in arguments {
+            let default_value_ptr = arg
+                .default_value
+                .as_ref()
+                .map(|s| s.as_ptr())
+                .unwrap_or(std::ptr::null());
+            let arg_info = if let Some(ref type_hint) = arg.type_hint {
+                match type_hint {
+                    ArgumentTypeHint::Mixed => {
+                        if PHP_MAJOR_VERSION < 8 {
+                            None
+                        } else {
+                            unsafe {
                                 Some(phper_zend_arg_info_with_type(
                                     arg.pass_by_ref,
                                     arg.name.as_ptr(),
@@ -343,9 +231,11 @@ impl FunctionEntry {
                                 ))
                             }
                         }
-                        ArgumentTypeHint::ClassEntry(class_name) => {
-                            let c_class_name =
-                                CString::new(class_name.clone()).expect("CString::new failed");
+                    }
+                    ArgumentTypeHint::ClassEntry(class_name) => {
+                        let c_class_name =
+                            CString::new(class_name.clone()).expect("CString::new failed");
+                        unsafe {
                             Some(phper_zend_arg_obj_info(
                                 arg.pass_by_ref,
                                 arg.name.as_ptr(),
@@ -354,39 +244,47 @@ impl FunctionEntry {
                             ))
                         }
                     }
-                } else {
-                    None
-                };
+                    hint => hint.zend_type_const().map(|type_const| unsafe {
+                        phper_zend_arg_info_with_type(
+                            arg.pass_by_ref,
+                            arg.name.as_ptr(),
+                            type_const,
+                            arg.nullable,
+                            default_value_ptr,
+                        )
+                    }),
+                }
+            } else {
+                None
+            };
 
-                infos
-                    .push(arg_info.unwrap_or_else(|| {
-                        phper_zend_arg_info(arg.pass_by_ref, arg.name.as_ptr())
-                    }));
-            }
+            infos.push(arg_info.unwrap_or_else(|| unsafe {
+                phper_zend_arg_info(arg.pass_by_ref, arg.name.as_ptr())
+            }));
+        }
 
-            infos.push(zeroed::<zend_internal_arg_info>());
+        infos.push(unsafe { zeroed::<zend_internal_arg_info>() });
 
-            let raw_handler = handler.as_ref().map(|_| invoke as _);
+        let raw_handler = handler.as_ref().map(|_| invoke as _);
 
-            if let Some(handler) = handler {
-                let translator = CallableTranslator {
-                    callable: Rc::into_raw(handler),
-                };
-                let last_arg_info: zend_internal_arg_info = translator.internal_arg_info;
-                infos.push(last_arg_info);
-            }
+        if let Some(handler) = handler {
+            let translator = CallableTranslator {
+                callable: Rc::into_raw(handler),
+            };
+            let last_arg_info: zend_internal_arg_info = unsafe { translator.internal_arg_info };
+            infos.push(last_arg_info);
+        }
 
-            let flags = visibility.unwrap_or(Visibility::default() as u32);
+        let flags = visibility.unwrap_or(Visibility::default() as u32);
 
-            #[allow(clippy::needless_update)]
-            zend_function_entry {
-                fname: name.as_ptr().cast(),
-                handler: raw_handler,
-                arg_info: Box::into_raw(infos.into_boxed_slice()).cast(),
-                num_args: arguments.len() as u32,
-                flags,
-                ..Default::default()
-            }
+        #[allow(clippy::needless_update)]
+        zend_function_entry {
+            fname: name.as_ptr().cast(),
+            handler: raw_handler,
+            arg_info: Box::into_raw(infos.into_boxed_slice()).cast(),
+            num_args: arguments.len() as u32,
+            flags,
+            ..Default::default()
         }
     }
 }

--- a/phper/src/lib.rs
+++ b/phper/src/lib.rs
@@ -14,7 +14,6 @@
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/112468984?s=200&v=4")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[macro_use]
 mod macros;
 
 pub mod alloc;
@@ -36,5 +35,5 @@ mod utils;
 pub mod values;
 
 pub use crate::errors::{Error, Result, ok};
-pub use phper_macros::*;
+pub use phper_macros::php_get_module;
 pub use phper_sys as sys;

--- a/phper/src/macros.rs
+++ b/phper/src/macros.rs
@@ -27,7 +27,7 @@ macro_rules! echo {
 /// # Examples
 ///
 /// ```no_test
-/// phper::errro!("Hello, {}!", message)
+/// phper::error!("Hello, {}!", message)
 /// ```
 #[macro_export]
 macro_rules! error {

--- a/phper/src/modules.rs
+++ b/phper/src/modules.rs
@@ -256,6 +256,9 @@ impl Module {
     /// Register class to module.
     pub fn add_class<T>(&mut self, class: ClassEntity<T>) -> StateClass<T> {
         let bound_class = class.bound_class();
+        // SAFETY: The type parameter `T` is erased to `()` for storage in the
+        // heterogeneous collection. The actual type is recovered later via
+        // `StateObj<T>` at handler invocation time through the bound class.
         self.class_entities
             .push(unsafe { transmute::<ClassEntity<T>, ClassEntity<()>>(class) });
         bound_class
@@ -274,6 +277,9 @@ impl Module {
         &mut self, enum_entity: crate::enums::EnumEntity<B>,
     ) -> crate::enums::Enum {
         let bound_enum = enum_entity.bound_enum();
+        // SAFETY: The type parameter `B` is erased to `()` for storage in the
+        // heterogeneous collection. The actual type is recovered later through
+        // the bound enum handle.
         self.enum_entities.push(unsafe {
             transmute::<crate::enums::EnumEntity<B>, crate::enums::EnumEntity<()>>(enum_entity)
         });

--- a/phper/src/types.rs
+++ b/phper/src/types.rs
@@ -245,6 +245,26 @@ pub enum ArgumentTypeHint {
     ClassEntry(String),
 }
 
+impl ArgumentTypeHint {
+    /// Returns the Zend type constant for this type hint, if it maps to a
+    /// simple constant.
+    pub(crate) fn zend_type_const(&self) -> Option<u32> {
+        match self {
+            Self::Null => Some(IS_NULL),
+            Self::Bool => Some(_IS_BOOL),
+            Self::Int => Some(IS_LONG),
+            Self::Float => Some(IS_DOUBLE),
+            Self::String => Some(IS_STRING),
+            Self::Array => Some(IS_ARRAY),
+            Self::Object => Some(IS_OBJECT),
+            Self::Callable => Some(IS_CALLABLE),
+            Self::Iterable => Some(IS_ITERABLE),
+            Self::Mixed => Some(IS_MIXED),
+            Self::ClassEntry(_) => None,
+        }
+    }
+}
+
 /// PHP return typehints
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReturnTypeHint {
@@ -274,4 +294,24 @@ pub enum ReturnTypeHint {
     Never,
     /// void typehint
     Void,
+}
+
+impl ReturnTypeHint {
+    /// Returns the Zend type constant for this type hint, if it maps to a
+    /// simple constant.
+    pub(crate) fn zend_type_const(&self) -> Option<u32> {
+        match self {
+            Self::Null => Some(IS_NULL),
+            Self::Bool => Some(_IS_BOOL),
+            Self::Int => Some(IS_LONG),
+            Self::Float => Some(IS_DOUBLE),
+            Self::String => Some(IS_STRING),
+            Self::Array => Some(IS_ARRAY),
+            Self::Object => Some(IS_OBJECT),
+            Self::Callable => Some(IS_CALLABLE),
+            Self::Iterable => Some(IS_ITERABLE),
+            Self::Mixed => Some(IS_MIXED),
+            Self::ClassEntry(_) | Self::Never | Self::Void => None,
+        }
+    }
 }


### PR DESCRIPTION
Refactor type hints and migrate to modern GitHub Actions

Introduce `zend_type_const()` helper methods on `ArgumentTypeHint` and `ReturnTypeHint` to centralize Zend type constant mapping. Update `FunctionEntry::build` and `Throwable for Error` to use the new helpers and a delegate macro, reducing code duplication.

Migrate CI workflows to latest `actions/checkout@v4`, `dtolnay/rust-toolchain`, and `actions/cache@v4`. Run cargo commands directly instead of through actions-rs wrappers. Update the `execute_command` error message to include the underlying error.

Add safety comments for unsafe transmutes in Module, improve TODO descriptions, and fix a typo in the `error!` macro doctest.